### PR TITLE
allow query comment inection

### DIFF
--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -498,6 +498,7 @@ class FabricConnectionManager(SQLConnectionManager):
     def execute(
         self, sql: str, auto_begin: bool = True, fetch: bool = False, limit: Optional[int] = None
     ) -> Tuple[AdapterResponse, agate.Table]:
+        sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
         response = self.get_response(cursor)
         if fetch:


### PR DESCRIPTION
resolves: #96 

> As an adapter maintainer, do I need to do anything to allow query-comment injection to the sql queries?
>   @prdpsvs ([community slack #adapter-ecosystem thread](https://getdbt.slack.com/archives/C030A0UF5LM/p1700688466953059))

Looks like this line was missing that does exist in the parent class method `SQLAdapter`.


https://github.com/dbt-labs/dbt-core/blame/main/core/dbt/adapters/sql/connections.py#L137C9-L137C43