### PR TITLE
v1.7.2 release

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ## Enhancements
 * Bump dbt-tests-adapter requirement from ~=1.7.2 to ~=1.7.3
-* Bump pre-commit from 3.5.0 to 3.6.0
 * Bump actions/setup-python from 4 to 5
 
 ### v1.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### v1.7.2
+
+## Bug Fixes
+* Addressed issue [#53](https://github.com/microsoft/dbt-fabric/issues/101) - "The server supports a maximum of 2100 parameters" by reducing the batch size by 1 if number of insert value parameters exceed 2100.
+* Added bytearry data type code support along bytes for varbinary sql datatype.
+
+## Enhancements
+* Bump dbt-tests-adapter requirement from ~=1.7.2 to ~=1.7.3
+* Bump pre-commit from 3.5.0 to 3.6.0
+* Bump actions/setup-python from 4 to 5
+
 ### v1.7.1
 
 ## Features

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.1"
+version = "1.7.2"

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -41,6 +41,7 @@ datatypes = {
     # "int": "tinyint",
     "int": "int",
     "bytes": "varbinary",
+    "bytearray": "varbinary",
     "bool": "bit",
     "datetime.date": "date",
     "datetime.datetime": "datetime2(6)",

--- a/dbt/include/fabric/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/seeds/helpers.sql
@@ -13,7 +13,7 @@
         reduce the batch size so it fits.
     #}
     {% set max_batch_size = get_batch_size() %}
-    {% set calculated_batch = (2100 / num_columns)|int %}
+    {% set calculated_batch = (2100 / num_columns)-1|int %}
     {% set batch_size = [max_batch_size, calculated_batch] | min %}
 
     {{ return(batch_size) }}

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,9 @@
 pytest==7.4.3
 twine==4.0.2
 wheel==0.42
-pre-commit==3.5.0
+pre-commit==3.6.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter~=1.7.2
+dbt-tests-adapter~=1.7.3
 flaky==3.7.0
 pytest-xdist==3.5.0
 -e .

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,7 +1,7 @@
 pytest==7.4.3
 twine==4.0.2
 wheel==0.42
-pre-commit==3.6.0
+pre-commit==3.5.0
 pytest-dotenv==0.5.2
 dbt-tests-adapter~=1.7.3
 flaky==3.7.0


### PR DESCRIPTION
## Bug Fixes
* Addressed issue [#53](https://github.com/microsoft/dbt-fabric/issues/101) - "The server supports a maximum of 2100 parameters" by reducing the batch size by 1 if number of insert value parameters exceed 2100.
* Added bytearry data type code support along bytes for varbinary sql datatype.

## Enhancements
* Bump dbt-tests-adapter requirement from ~=1.7.2 to ~=1.7.3
* Bump pre-commit from 3.5.0 to 3.6.0
* Bump actions/setup-python from 4 to 5