### PR TITLE
v1.8.0rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ### v1.8.0rc1
 
+## Features
+
+Supporting dbt-core 1.8.0
+
+## Bug fixes
+
+* Refactor relations to query from sys catalog instead of information schema causing concurrency issues when running multiple threads in parallel (https://github.com/microsoft/dbt-fabric/issues/52).
+
+## Enhancements
+
 [Decouple imports](https://github.com/dbt-labs/dbt-adapters/discussions/87) to common dbt core and dbt adapter interface packages for future maintainability and extensibility.
 
 * Bump adapter packages
@@ -9,8 +19,7 @@
 
 > From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!
 
-## Enhancements
-* Refactor relations to query from sys catalog instead of information schema causing concurrency issues when running multiple threads in parallel (https://github.com/microsoft/dbt-fabric/issues/52).
+
 * Bump dev requirements
     - from pytest~=7.4. to pytest~=8.0.1
     - from twine~=4.0.2 to twine~=5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### v1.8.0rc1
+
+[Decouple imports](https://github.com/dbt-labs/dbt-adapters/discussions/87) to common dbt core and dbt adapter interface packages for future maintainability and extensibility.
+
+* Bump adapter packages
+    - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0
+
+> From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!
+
+## Enhancements
+* Refactor relations to query from sys catalog instead of information schema causing concurrency issues when running multiple threads in parallel (https://github.com/microsoft/dbt-fabric/issues/52).
+* Bump dev requirements
+    - from pytest~=7.4. to pytest~=8.0.1
+    - from twine~=4.0.2 to twine~=5.0.0
+    - from pre-commit~=3.5.0 to pre-commit~=3.6.2
+
 ### v1.7.3
 
 ## Enhancements

--- a/dbt/adapters/fabric/__init__.py
+++ b/dbt/adapters/fabric/__init__.py
@@ -1,11 +1,11 @@
 from dbt.adapters.base import AdapterPlugin
+from dbt.adapters.include import fabric
 
 from dbt.adapters.fabric.fabric_adapter import FabricAdapter
 from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs
 from dbt.adapters.fabric.fabric_connection_manager import FabricConnectionManager
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
-from dbt.include import fabric
 
 Plugin = AdapterPlugin(
     adapter=FabricAdapter,

--- a/dbt/adapters/fabric/__init__.py
+++ b/dbt/adapters/fabric/__init__.py
@@ -1,11 +1,11 @@
 from dbt.adapters.base import AdapterPlugin
-from dbt.adapters.include import fabric
 
 from dbt.adapters.fabric.fabric_adapter import FabricAdapter
 from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs
 from dbt.adapters.fabric.fabric_connection_manager import FabricConnectionManager
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
+from dbt.include import fabric
 
 Plugin = AdapterPlugin(
     adapter=FabricAdapter,

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.4"
+version = "1.8.0rc1"

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0rc1"
+version = "1.8.0a1"

--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -8,7 +8,6 @@ from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.cache import _make_ref_key_dict
 from dbt.adapters.capability import Capability, CapabilityDict, CapabilitySupport, Support
-from dbt.adapters.events.functions import fire_event
 from dbt.adapters.events.types import SchemaCreation
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.sql.impl import CREATE_SCHEMA_MACRO_NAME
@@ -17,6 +16,7 @@ from dbt_common.contracts.constraints import (
     ConstraintType,
     ModelLevelConstraint,
 )
+from dbt_common.events.functions import fire_event
 
 from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs

--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -1,23 +1,22 @@
 from typing import List, Optional
 
 import agate
-import dbt.exceptions
+import dbt_common.exceptions
 from dbt.adapters.base import Column as BaseColumn
-
-# from dbt.events.functions import fire_event
-# from dbt.events.types import SchemaCreation
 from dbt.adapters.base.impl import ConstraintSupport
 from dbt.adapters.base.meta import available
 from dbt.adapters.base.relation import BaseRelation
 from dbt.adapters.cache import _make_ref_key_dict
 from dbt.adapters.capability import Capability, CapabilityDict, CapabilitySupport, Support
-
-# from dbt.adapters.cache import _make_ref_key_msg
+from dbt.adapters.events.functions import fire_event
+from dbt.adapters.events.types import SchemaCreation
 from dbt.adapters.sql import SQLAdapter
 from dbt.adapters.sql.impl import CREATE_SCHEMA_MACRO_NAME
-from dbt.contracts.graph.nodes import ColumnLevelConstraint, ConstraintType, ModelLevelConstraint
-from dbt.events.functions import fire_event
-from dbt.events.types import SchemaCreation
+from dbt_common.contracts.constraints import (
+    ColumnLevelConstraint,
+    ConstraintType,
+    ModelLevelConstraint,
+)
 
 from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs
@@ -204,7 +203,7 @@ class FabricAdapter(SQLAdapter):
         column_list = ", ".join(constraint.columns)
 
         if constraint.name is None:
-            raise dbt.exceptions.DbtDatabaseError(
+            raise dbt_common.exceptions.DbtDatabaseError(
                 "Constraint name cannot be empty. Provide constraint name  - column "
                 + column_list
                 + " and run the project again."

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -17,7 +17,7 @@ from dbt.adapters.sql import SQLConnectionManager
 from dbt_common.clients.agate_helper import empty_table
 from dbt_common.events.contextvars import get_node_info
 from dbt_common.events.functions import fire_event
-from dbt_common.utils.encoding import cast_to_str
+from dbt_common.utils.casting import cast_to_str
 
 from dbt.adapters.fabric import __version__
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials

--- a/dbt/adapters/fabric/fabric_credentials.py
+++ b/dbt/adapters/fabric/fabric_credentials.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from dbt.contracts.connection import Credentials
+from dbt.adapters.contracts.connection import Credentials
 
 
 @dataclass

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,7 +7,7 @@ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 pytest==8.0.1
 twine==5.0.0
 wheel==0.42
-pre-commit==3.5.0
+pre-commit==3.6.2
 pytest-dotenv==0.5.2
 flaky==3.7.0
 pytest-xdist==3.5.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,7 +7,8 @@ git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
 pytest==8.0.1
 twine==5.0.0
 wheel==0.42
-pre-commit==3.6.2
+pre-commit==3.5.0;python_version<"3.9"
+pre-commit==3.6.2;python_version>="3.9"
 pytest-dotenv==0.5.2
 flaky==3.7.0
 pytest-xdist==3.5.0

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,14 @@
+# install latest changes in dbt-core
+# TODO: how to automate switching from develop to version branches?
+git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git
+git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+
 pytest==8.0.1
 twine==5.0.0
 wheel==0.42
 pre-commit==3.5.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter~=1.7.8
 flaky==3.7.0
 pytest-xdist==3.5.0
 -e .

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,9 +1,9 @@
-pytest==7.4.4
-twine==4.0.2
+pytest==8.0.1
+twine==5.0.0
 wheel==0.42
 pre-commit==3.5.0
 pytest-dotenv==0.5.2
-dbt-tests-adapter~=1.7.4
+dbt-tests-adapter~=1.7.8
 flaky==3.7.0
 pytest-xdist==3.5.0
 -e .

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools.command.install import install
 
 package_name = "dbt-fabric"
 authors_list = ["Pradeep Srikakolapu"]
-dbt_version = "1.7"
+dbt_version = "1.8"
 description = """A Microsoft Fabric Synapse Data Warehouse adapter plugin for dbt"""
 
 this_directory = os.path.abspath(os.path.dirname(__file__))
@@ -66,9 +66,10 @@ setup(
     packages=find_namespace_packages(include=["dbt", "dbt.*"]),
     include_package_data=True,
     install_requires=[
-        "dbt-core~=1.7.2",
-        "pyodbc>=4.0.35,<5.1.0",
+        "pyodbc>=4.0.35,<5.2.0",
         "azure-identity>=1.12.0",
+        "dbt-common~=0.1.5",
+        "dbt-adapters~=0.1.0a6",
     ],
     cmdclass={
         "verify": VerifyVersionCommand,

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     install_requires=[
         "pyodbc>=4.0.35,<5.2.0",
         "azure-identity>=1.12.0",
-        "dbt-common~=0.1.5",
+        "dbt-common~=0.1.6",
         "dbt-adapters~=0.1.0a6",
     ],
     cmdclass={

--- a/tests/functional/adapter/test_dbt_clone.py
+++ b/tests/functional/adapter/test_dbt_clone.py
@@ -4,7 +4,6 @@ from collections import Counter
 from copy import deepcopy
 
 import pytest
-from dbt.exceptions import DbtRuntimeError
 from dbt.tests.adapter.dbt_clone.fixtures import (
     custom_can_clone_tables_false_macros_sql,
     ephemeral_model_sql,
@@ -19,6 +18,7 @@ from dbt.tests.adapter.dbt_clone.fixtures import (
     view_model_sql,
 )
 from dbt.tests.util import run_dbt
+from dbt_common.exceptions import DbtRuntimeError
 
 
 class BaseClone:


### PR DESCRIPTION
## Features

Supporting dbt-core 1.8.0

## Bug fixes

* Refactor list relation macros to use sys catalog instead of information schema causing concurrency issues when running multiple threads in parallel (https://github.com/microsoft/dbt-fabric/issues/52).

This change allows us to run our integration tests but from occasionally there are still locks.

```
E pyodbc.ProgrammingError: ('42000', "[42000] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Snapshot isolation transaction failed in database 'dbtfabricadapter' because the object accessed by the statement has been modified by a DDL statement in another concurrent transaction since the start of this transaction.  It is disallowed because the metadata is not versioned. A concurrent update to metadata can lead to inconsistency if mixed with snapshot isolation. (3961) (SQLExecDirectW)")
```

Fabric only support Snapshot isolation level, so the "trick" of turning [off and on ](https://techcommunity.microsoft.com/t5/azure-database-support-blog/snapshot-isolation-transaction-fails-when-querying-metadata/ba-p/1827281)again is not going to work i think...

couple refs: 
- https://stackoverflow.com/questions/74278290/sql-server-set-transaction-isolation-level-read-committed-does-not-appear-to-work
- https://community.fabric.microsoft.com/t5/General-Discussion/Fabric-Data-Warehouse-stored-proc-fails-Snapshot-isolation/m-p/3665959.
- Also recommended to set too non-isolation before commit for SQL Server official docs [here](https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-3961-database-engine-error?view=sql-server-ver16#user-action).

TLDR, for Fabric we have a limitation of having only one isolation level which imo can't be changed, nor switched off with `SET TRANSACTION` hints so at this point i see no workaround until Fabric starts to support other isolation types.

## Enhancements

[Decouple imports](https://github.com/dbt-labs/dbt-adapters/discussions/87) to common dbt core and dbt adapter interface packages for future maintainability and extensibility.

* Bump adapter packages
    - from pyodbc>=4.0.35,<5.1.0" to pyodbc>=4.0.35,<5.2.0

> From now on, Apple-silicon users don't have to locally build pyodbc, because M1, M2 binaries is included in pyodbc from 5.1.0 onwards!


* Bump dev requirements
    - from pytest~=7.4. to pytest~=8.0.1
    - from twine~=4.0.2 to twine~=5.0.0
    - from pre-commit~=3.5.0 to pre-commit~=3.6.2