### PR TITLE
v1.8.0rc2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v1.8.0rc2
+
+## Bug Fixes
+* Remove dbt-adapters requirement in setup.py, and specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix `make dev`
+* Fix failing test `tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment` to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)
+
 ### v1.8.0rc1
 
 ## Features

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0rc1"
+version = "1.8.0rc2"

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.8.0a1"
+version = "1.8.0rc1"

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,8 +1,8 @@
 # install latest changes in dbt-core
 # TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-adapters.git
-git+https://github.com/dbt-labs/dbt-adapters.git#subdirectory=dbt-tests-adapter
+git+https://github.com/dbt-labs/dbt-core.git@fc431010ef0bd11ee6a502fc6c9e5e3e75c5d72d#egg=dbt-core&subdirectory=core
+git+https://github.com/dbt-labs/dbt-adapters.git@4c289b150853b94beb67921f2a8dd203abe53cbe
+git+https://github.com/dbt-labs/dbt-adapters.git@4c289b150853b94beb67921f2a8dd203abe53cbe#subdirectory=dbt-tests-adapter
 
 pytest==8.0.1
 twine==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,6 @@ setup(
         "pyodbc>=4.0.35,<5.2.0",
         "azure-identity>=1.12.0",
         "dbt-common~=0.1.6",
-        "dbt-adapters~=0.1.0a6",
     ],
     cmdclass={
         "verify": VerifyVersionCommand,

--- a/tests/functional/adapter/test_query_comment.py
+++ b/tests/functional/adapter/test_query_comment.py
@@ -6,6 +6,8 @@ from dbt.tests.adapter.query_comment.test_query_comment import (
     BaseNullQueryComments,
     BaseQueryComments,
 )
+from dbt.version import __version__ as dbt_version
+import json
 
 
 # Tests #
@@ -18,7 +20,18 @@ class TestMacroQueryComments(BaseMacroQueryComments):
 
 
 class TestMacroArgsQueryComments(BaseMacroArgsQueryComments):
-    pass
+    def test_matches_comment(self, project) -> bool:
+        logs = self.run_get_json()
+        expected_dct = {
+            "app": "dbt++",
+            "dbt_version": dbt_version,
+            "macro_version": "0.1.0",
+            "message": f"blah: {project.adapter.config.target_name}",
+        }
+        expected = r"/* {} */\n".format(json.dumps(expected_dct, sort_keys=True)).replace(
+            '"', r"\""
+        )
+        assert expected in logs
 
 
 class TestMacroInvalidQueryComments(BaseMacroInvalidQueryComments):


### PR DESCRIPTION
for pre-release v1.8.0rc2,
* Remove dbt-adapters requirement in setup.py, and specify commit SHA of dbt-core and dbt-adapters in dev_requirements.txt, to fix `make dev`
* Fix failing test `tests/functional/adapter/test_query_comment.py::TestMacroArgsQueryComments::test_matches_comment` to use correct dbt_version, see [dbt-core](https://github.com/dbt-labs/dbt-core/blob/main/tests/functional/adapter/query_comment/test_query_comment.py)