### PR TITLE
Update seeds/helpers.sql, fix calculated_batch calculation

### DIFF
--- a/dbt/include/fabric/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/seeds/helpers.sql
@@ -13,7 +13,7 @@
         reduce the batch size so it fits.
     #}
     {% set max_batch_size = get_batch_size() %}
-    {% set calculated_batch = (2100 / num_columns)-1|int %}
+    {% set calculated_batch = ((2100 / num_columns)-1)|int %}
     {% set batch_size = [max_batch_size, calculated_batch] | min %}
 
     {{ return(batch_size) }}


### PR DESCRIPTION
Add brackets around the calculated_batch calculation because the | int filter did only apply on the -1 so the result was a decimal number which broke the seed-batch-loading
Related issue #206 