### PR TITLE
Update show.sql to reflect macro name change

### DIFF
--- a/dbt/include/fabric/macros/adapters/show.sql
+++ b/dbt/include/fabric/macros/adapters/show.sql
@@ -1,4 +1,4 @@
-{% macro fabric__get_limit_subquery_sql(sql, limit) %}
+{% macro fabric__get_limit_sql(sql, limit) %}
 
     {% if sql.strip().lower().startswith('with') %}
         {{ sql }} order by (select null)


### PR DESCRIPTION
We renamed this macro in [dbt-adapters](https://github.com/dbt-labs/dbt-adapters/blob/d2842a73d11b2e49d72d87429314e96eae0574fe/dbt/include/global_project/macros/adapters/show.sql#L21) and need to rename it here as well. 

As a result `dbt show some_table.sql --limit 1` will fail as this macro won't be picked up