### PR TITLE
Ensure Testview Name Uniqueness with MD5 of Model Name and Invocation ID

### DIFF
--- a/dbt/include/fabric/macros/materializations/tests/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/tests/helpers.sql
@@ -9,7 +9,7 @@
 
   {% if main_sql.strip().lower().startswith('with') %}
     {% set testview %}
-      [{{ target.schema }}.testview_{{ range(1300, 19000) | random }}]
+      [{{ target.schema }}.testview_{{ local_md5(model.name ~ invocation_id) }}]
     {% endset %}
 
     {% set sql = main_sql.replace("'", "''")%}


### PR DESCRIPTION
# Problem

Every dbt test creates a view with the name "testview_<random_number>". If a test can not be executed, maybe because a column name is wrong, the view doesn't get dropped afterwards. 

The next iteration might want to create a view with the same name, because the range of the random funtion is quite limited. It can't create that, because the name is already taken (if you are unlucky). This leads to an error. 

# Solution

Instead of using a random function, I used `testview_{{ local_md5(model.name ~ invocation_id) }}`. Not using MD5 would be nicer for readability, but you might run into issues regarding the maximum object name length of 128 characters. 