### PR TITLE
split part fix for -ve part numbers and removed generate_custom_schema macro in the adapter

### DIFF
--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.2"
+version = "1.9.3"

--- a/dbt/include/fabric/macros/materializations/tests/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/tests/helpers.sql
@@ -52,14 +52,3 @@
   SELECT * FROM dbt_internal_unit_test_expected
 
 {%- endmacro %}
-
-
-{% macro fabric__generate_schema_name(custom_schema_name, node) -%}
-
-    {%- set default_schema = target.schema -%}
-    {%- if custom_schema_name is none -%}
-        {{ default_schema }}
-    {%- else -%}
-        {{ custom_schema_name | trim }}
-    {%- endif -%}
-{%- endmacro %}

--- a/dbt/include/fabric/macros/utils/split_part.sql
+++ b/dbt/include/fabric/macros/utils/split_part.sql
@@ -1,8 +1,19 @@
 {% macro fabric__split_part(string_text, delimiter_text, part_number) %}
-    {% if part_number >= 0 %}
-        (select value from string_split({{ string_text }}, {{ delimiter_text }}, 1) where ordinal = {{ part_number }})
+    WITH SplitData AS (
+        SELECT value,
+        {% if part_number > 0 %}
+            , ROW_NUMBER() OVER (ORDER BY ordinal ASC) AS forward_index
+        {% else %}
+            , ROW_NUMBER() OVER (ORDER BY ordinal DESC) AS backward_index
+        {% endif %}
+        FROM string_split({{ string_text }}, {{ delimiter_text }}, 1)
+    )
+    SELECT value
+    FROM SplitData
+    WHERE
+    {% if part_number > 0 %}
+        forward_index = {{ part_number }}
     {% else %}
-        (select value from string_split({{ string_text }}, {{ delimiter_text }}, 1)
-        where ordinal = len(replace({{ string_text }}, {{delimiter_text}}, '')) + 1 + {{ part_number }})
+        backward_index = {{ abs(part_number) }}
     {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This pull request includes several changes to the `dbt` package, primarily focusing on updating the version number, removing an unused macro, and improving the logic of an existing macro.

Version update:

* [`dbt/adapters/fabric/__version__.py`](diffhunk://#diff-2abc96fe291d711fb6ae8c7370a98b371e48704f6ff382d966c49c736874aef4L1-R1): Updated the version number from `1.9.2` to `1.9.3`.

Code cleanup:

* [`dbt/include/fabric/macros/materializations/tests/helpers.sql`](diffhunk://#diff-2dab2f04a9206a68a00332ab56f9bb388a9a75dd3a2edc6e531c5f802982cb42L55-L65): Removed the unused `fabric__generate_schema_name` macro.

Macro improvement:

* [`dbt/include/fabric/macros/utils/split_part.sql`](diffhunk://#diff-917a4a05004666d0f6d8176afdd1778f8dd37b56a7b3afd609a79ed71edf15c5L2-R17): Enhanced the `fabric__split_part` macro by using a common table expression (CTE) to handle both forward and backward indexing efficiently.