### PR TITLE
Stop requiring aliases on subqueries.

### DIFF
--- a/dbt/adapters/fabric/fabric_relation.py
+++ b/dbt/adapters/fabric/fabric_relation.py
@@ -11,6 +11,7 @@ from dbt.adapters.fabric.relation_configs import FabricQuotePolicy, FabricRelati
 class FabricRelation(BaseRelation):
     type: Optional[FabricRelationType] = None  # type: ignore
     quote_policy: FabricQuotePolicy = field(default_factory=lambda: FabricQuotePolicy())
+    require_alias: bool = False
 
     @classproperty
     def get_relation_type(cls) -> Type[FabricRelationType]:

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,4 +1,7 @@
-# from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+from dbt.tests.adapter.empty.test_empty import BaseTestEmptyInlineSourceRef
 
 # class TestEmpty(BaseTestEmpty):
 #     pass
+
+class TestFabricEmptyInlineSourceRef(BaseTestEmptyInlineSourceRef):
+    pass


### PR DESCRIPTION
Closes: https://github.com/dbt-labs/dbt-adapters/issues/807
Closes: #255 

cc: @prdpsvs 

## Problem

Aliasing shouldn't be required on certain dbt subqueries in Fabric. This is a requirement of adapters like Postgres and something we frequently override for those adapters where this fails.

## Solution

This can be configured per-adapter by overriding the repo's `*Relation` class' `require_alias` property.

Note: I tried adding this test but since `TestEmpty` is commented out we may just need to not include any tests. I'll let you decide what makes sense for the repo. 