### PR TITLE
Fabric Notebook Credential Passthrough

### DIFF
--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -114,7 +114,7 @@ def get_synapse_spark_access_token(credentials: FabricCredentials) -> AccessToke
 
 def get_fabric_notebook_access_token(credentials: FabricCredentials) -> AccessToken:
     """
-    Get an Azure access token by using notebookutiles. Works in both Fabric pyspark and python notebooks.
+    Get an Azure access token by using notebookutils. Works in both Fabric pyspark and python notebooks.
     Parameters
     -----------
     credentials: FabricCredentials


### PR DESCRIPTION
 Adds support for Microsoft Fabric notebook authentication by implementing a new fabricnotebook authentication method.

Similar to the synapsespark method but now uses notebookutils directly to provide support for faster python notebooks.
  
Changes

  - Added FABRIC_NOTEBOOK_CREDENTIAL_SCOPE constant for Fabric notebook authentication
  - Updated SYNAPSE_SPARK_CREDENTIAL_SCOPE to use "DW" scope instead of the full database URL
  - Implemented get_fabric_notebook_access_token() function that works with both Fabric PySpark and Python notebooks
  - Added fabricnotebook authentication method to AZURE_AUTH_FUNCTIONS mapping