### PR TITLE
Add merge incremental strategy support

### DIFF
--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -177,7 +177,7 @@ class FabricAdapter(SQLAdapter):
         """The set of standard builtin strategies which this adapter supports out-of-the-box.
         Not used to validate custom strategies defined by end users.
         """
-        return ["append", "delete+insert", "microbatch"]
+        return ["append", "delete+insert", "merge", "microbatch"]
 
     # This is for use in the test suite
     def run_sql_for_tests(self, sql, fetch, conn):

--- a/dbt/include/fabric/macros/materializations/models/incremental/incremental_strategies.sql
+++ b/dbt/include/fabric/macros/materializations/models/incremental/incremental_strategies.sql
@@ -9,3 +9,15 @@
     {% endif %}
 
 {% endmacro %}
+
+{% macro fabric__get_incremental_merge_sql(arg_dict) %}
+
+    {%- set target = arg_dict["target_relation"] -%}
+    {%- set source = arg_dict["temp_relation"] -%}
+    {%- set unique_key = arg_dict["unique_key"] -%}
+    {%- set dest_columns = arg_dict["dest_columns"] -%}
+    {%- set incremental_predicates = [] if arg_dict.get('incremental_predicates') is none else arg_dict.get('incremental_predicates') -%}
+
+    {% do return(fabric__get_merge_sql(target, source, unique_key, dest_columns, incremental_predicates)) %}
+
+{% endmacro %}


### PR DESCRIPTION
Enables the merge incremental strategy for dbt-fabric by:
- Adding "merge" to valid_incremental_strategies in FabricAdapter
- Creating fabric__get_incremental_merge_sql macro that delegates to existing fabric__get_merge_sql

This leverages the existing merge functionality while properly integrating with dbt's incremental strategy system.