### PR TITLE
Fix get_columns_in_relation datatypes for UNICODE datatypes

### DIFF
--- a/dbt/include/fabric/macros/adapters/columns.sql
+++ b/dbt/include/fabric/macros/adapters/columns.sql
@@ -15,7 +15,10 @@
                 row_number() over (partition by object_name(c.object_id) order by c.column_id) as ordinal_position,
                 c.name collate database_default as column_name,
                 t.name as data_type,
-                c.max_length as character_maximum_length,
+                case
+					when (t.name in ('nchar', 'nvarchar', 'sysname') and c.max_length <> -1) then c.max_length / 2
+					else c.max_length
+				end as character_maximum_length,
                 c.precision as numeric_precision,
                 c.scale as numeric_scale
             from sys.columns c {{ information_schema_hints() }}


### PR DESCRIPTION
### Issue

UNICODE datatypes (`nvarchar`, `nchar`, `sysname`) need two bytes per character. 
If a source column has the datatype `nvarchar(4000)`, the `sys.columns` shows `max_length` = 8000, because it reflects the number of bytes required to store this value, see docs (here)[https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-columns-transact-sql?view=sql-server-ver17].

Since this is used to return the datatypes, the wrong datatype `nvarchar(8000)` is returned, which would actually cause errors, at least in MSSQL. 

### What's changed

Instead of just forwarding `sys.columns.max_length`, I have added a `CASE WHEN` that checks for the datatype. If the datatype is a UNICODE datatype (`nvarchar`, `nchar`, `sysname`), the `max_length` is divided by 2, unless `max_length` is set to `-1`, because that value is used to indicate `MAX`.  

