### PR TITLE
Updating workflow to make distribution compatible with pypi and added…

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -10,6 +10,7 @@ jobs:
   release-version:
     name: Release new version
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -18,7 +19,10 @@ jobs:
           python-version: '3.9'
 
       - name: Install dependencies
-        run: pip install -r dev_requirements.txt
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+          pip install -r dev_requirements.txt
 
       - name: Verify version match
         run: python setup.py verify
@@ -31,5 +35,6 @@ jobs:
 
       - name: Build and publish package
         run: |
-          python setup.py sdist bdist_wheel
+          rm -rf dist build *.egg-info
+          python -m build
           twine upload dist/*

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -36,6 +36,7 @@ TARGET_COMMANDS = {"run", "build", "snapshot"}
 
 AZURE_CREDENTIAL_SCOPE = "https://database.windows.net//.default"
 POWER_BI_CREDENTIAL_SCOPE = "https://api.fabric.microsoft.com/.default"
+FABRIC_NOTEBOOK_CREDENTIAL_SCOPE = "https://database.windows.net/"
 SYNAPSE_SPARK_CREDENTIAL_SCOPE = "DW"
 _TOKEN: Optional[AccessToken] = None
 AZURE_AUTH_FUNCTION_TYPE = Callable[[FabricCredentials, Optional[str]], AccessToken]
@@ -126,6 +127,31 @@ def get_synapse_spark_access_token(
     return token
 
 
+def get_fabric_notebook_access_token(
+    credentials: FabricCredentials, scope: Optional[str] = FABRIC_NOTEBOOK_CREDENTIAL_SCOPE
+) -> AccessToken:
+    """
+    Get an Azure access token by using notebookutils. Works in both Fabric pyspark and python notebooks.
+    Parameters
+    -----------
+    credentials: FabricCredentials
+        Credentials.
+    Returns
+    -------
+    out : AccessToken
+        The access token.
+    """
+    import notebookutils
+
+    aad_token = notebookutils.credentials.getToken(FABRIC_NOTEBOOK_CREDENTIAL_SCOPE)
+    expires_on = int(time.time() + 4500.0)
+    token = AccessToken(
+        token=aad_token,
+        expires_on=expires_on,
+    )
+    return token
+
+
 def get_cli_access_token(
     credentials: FabricCredentials, scope: Optional[str] = AZURE_CREDENTIAL_SCOPE
 ) -> AccessToken:
@@ -204,6 +230,7 @@ AZURE_AUTH_FUNCTIONS: Mapping[str, AZURE_AUTH_FUNCTION_TYPE] = {
     "auto": get_auto_access_token,
     "environment": get_environment_access_token,
     "synapsespark": get_synapse_spark_access_token,
+    "fabricnotebook": get_fabric_notebook_access_token,
 }
 
 

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -11,4 +11,5 @@ pre-commit==3.8.0;python_version>="3.9"
 pytest-dotenv==0.5.2
 flaky==3.7.0
 pytest-xdist==3.5.0
+build
 -e .


### PR DESCRIPTION
This pull request introduces improvements to both the release workflow and the Fabric adapter's authentication mechanisms. The changes enhance the reliability of package publishing and add support for obtaining access tokens in Fabric notebooks.

**Release workflow enhancements:**

* Improved dependency installation in `.github/workflows/release-version.yml` by upgrading `pip`, explicitly installing `build` and `twine`, and ensuring a clean build environment before publishing. [[1]](diffhunk://#diff-a838f9875a872cb62c11ddc6c001756b3c4c0eb4090b8323dd7f17ff9f51bcf5L21-R25) [[2]](diffhunk://#diff-a838f9875a872cb62c11ddc6c001756b3c4c0eb4090b8323dd7f17ff9f51bcf5L34-R39)
* Added `build` to `dev_requirements.txt` to support building packages locally and in CI.

**Fabric adapter authentication improvements:**

* Introduced `FABRIC_NOTEBOOK_CREDENTIAL_SCOPE` and a new `get_fabric_notebook_access_token` function in `fabric_connection_manager.py` to support Azure access token retrieval within Fabric notebooks using `notebookutils`. [[1]](diffhunk://#diff-c1b0256b44c042e86c431c5151b6c0812c05e8c047c1d4f9b12b0b9538cbdb55R39) [[2]](diffhunk://#diff-c1b0256b44c042e86c431c5151b6c0812c05e8c047c1d4f9b12b0b9538cbdb55R130-R154)
* Registered the new `"fabricnotebook"` authentication method in the `ACCESS_TOKEN_FUNCTIONS` mapping, enabling its use for connections.… fabric notebook connect