### PR TITLE
Fixes: microsoft/dbt-fabric#345

### DIFF
--- a/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -2,25 +2,27 @@
     {% set query_label = apply_label() %}
     {% set tmp_vw_relation = relation.incorporate(path={"identifier": relation.identifier ~ '__dbt_tmp_vw'}, type='view')-%}
     {% do adapter.drop_relation(tmp_vw_relation) %}
-    {{ get_create_view_as_sql(tmp_vw_relation, sql) }}
+    {% call statement('create_temp_view', fetch_result=False) %}
+        {{ get_create_view_as_sql(tmp_vw_relation, sql) }}
+    {% endcall %}
 
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
+        {% call statement('create_table_from_contract', fetch_result=False) %}
+            CREATE TABLE {{relation}}
+            {{ build_columns_constraints(relation) }}
+            {{ get_assert_columns_equivalent(sql)  }}
+        {% endcall %}
 
-        CREATE TABLE {{relation}}
-        {{ build_columns_constraints(relation) }}
-        {{ get_assert_columns_equivalent(sql)  }}
         {% set listColumns %}
             {% for column in model['columns'] %}
                 {{ "["~column~"]" }}{{ ", " if not loop.last }}
             {% endfor %}
         {%endset%}
-
         {% if not adapter.behavior.empty.no_warn %}
             INSERT INTO {{relation}} ({{listColumns}})
             SELECT {{listColumns}} FROM {{tmp_vw_relation}} {{ query_label }}
         {% endif %}
-
 
     {%- else %}
         {%- set query_label_option = query_label.replace("'", "''") -%}


### PR DESCRIPTION
Fixes the situation where the `rows_affected` property in `run_results.json` was always -1 for table and incremental models.

Copies the solution proposed here: [https://github.com/dbt-msft/dbt-sqlserver/issues/583](https://github.com/dbt-msft/dbt-sqlserver/issues/583)