### PR TITLE
Add openrowset, quoting/aliasing, and data clustering features

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,9 +72,11 @@ repos:
       - id: flake8
         args:
           - '--max-line-length=1000'
+          - '--extend-ignore=E203'
       - id: flake8
         args:
           - '--max-line-length=1000'
+          - '--extend-ignore=E203'
         alias: flake8-check
         stages:
           - manual

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.9.8"
+version = "1.9.9"

--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -28,6 +28,11 @@ from dbt.adapters.fabric.fabric_relation import FabricRelation
 class FabricAdapter(SQLAdapter):
     ConnectionManager = FabricConnectionManager
     Column = FabricColumn
+
+    @classmethod
+    def quote(cls, identifier):
+        return "[{}]".format(identifier)
+
     AdapterSpecificConfigs = FabricConfigs
     Relation = FabricRelation
 

--- a/dbt/adapters/fabric/fabric_column.py
+++ b/dbt/adapters/fabric/fabric_column.py
@@ -5,6 +5,10 @@ from dbt_common.exceptions import DbtRuntimeError
 
 
 class FabricColumn(Column):
+    @property
+    def quoted(self) -> str:
+        return "[{}]".format(self.column)
+
     TYPE_LABELS: ClassVar[Dict[str, str]] = {
         "STRING": "VARCHAR(8000)",
         "VARCHAR": "VARCHAR(8000)",

--- a/dbt/adapters/fabric/fabric_configs.py
+++ b/dbt/adapters/fabric/fabric_configs.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
+from typing import List, Optional
 
 from dbt.adapters.protocol import AdapterConfig
 
@@ -7,3 +7,4 @@ from dbt.adapters.protocol import AdapterConfig
 @dataclass
 class FabricConfigs(AdapterConfig):
     auto_provision_aad_principals: Optional[bool] = False
+    cluster_by: Optional[List[str]] = None

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -736,7 +736,7 @@ class FabricConnectionManager(SQLConnectionManager):
 
     @classmethod
     def data_type_code_to_name(cls, type_code: Union[str, str]) -> str:
-        data_type = str(type_code)[str(type_code).index("'") + 1 : str(type_code).rindex("'")]
+        data_type = str(type_code)[str(type_code).index("'") + 1 : str(type_code).rindex("'")]  # type: ignore
         return datatypes[data_type]
 
     def execute(
@@ -744,7 +744,6 @@ class FabricConnectionManager(SQLConnectionManager):
     ) -> Tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
-        response = self.get_response(cursor)
         if fetch:
             # Get the result of the first non-empty result set (if any)
             while cursor.description is None:
@@ -756,4 +755,9 @@ class FabricConnectionManager(SQLConnectionManager):
         # Step through all result sets so we process all errors
         while cursor.nextset():
             pass
+        # Get response after stepping through all result sets
+        # so that cursor.rowcount reflects the last statement executed.
+        # This fixes rows_affected being -1 for table materializations
+        # where CREATE VIEW runs before the actual INSERT/CTAS.
+        response = self.get_response(cursor)
         return response, table

--- a/dbt/adapters/fabric/fabric_relation.py
+++ b/dbt/adapters/fabric/fabric_relation.py
@@ -16,6 +16,9 @@ class FabricRelation(BaseRelation):
     quote_policy: FabricQuotePolicy = field(default_factory=lambda: FabricQuotePolicy())
     require_alias: bool = False
 
+    def quoted(self, identifier):
+        return "[{}]".format(identifier)
+
     @classproperty
     def get_relation_type(cls) -> Type[FabricRelationType]:
         return FabricRelationType

--- a/dbt/include/fabric/macros/adapters/columns.sql
+++ b/dbt/include/fabric/macros/adapters/columns.sql
@@ -90,7 +90,7 @@
 
     {% set tempTable %}
         CREATE TABLE {{tempTableName}}
-        AS SELECT {{query_result_text}}, CAST("{{ column_name }}" AS {{new_column_type}}) AS "{{column_name}}" FROM {{ relation.schema }}.{{ relation.identifier }}
+        AS SELECT {{query_result_text}}, CAST([{{ column_name }}] AS {{new_column_type}}) AS [{{column_name}}] FROM {{ relation.schema }}.{{ relation.identifier }}
         {{ apply_label() }}
     {% endset %}
 
@@ -129,12 +129,12 @@
   {% call statement('add_drop_columns') -%}
     {% if add_columns %}
         alter {{ relation.type }} {{ relation }}
-        add {% for column in add_columns %}"{{ column.name }}" {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
+        add {% for column in add_columns %}[{{ column.name }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
     {% endif %}
 
     {% if remove_columns %}
         alter {{ relation.type }} {{ relation }}
-        drop column {% for column in remove_columns %}"{{ column.name }}"{{ ',' if not loop.last }}{% endfor %};
+        drop column {% for column in remove_columns %}[{{ column.name }}]{{ ',' if not loop.last }}{% endfor %};
     {% endif %}
   {%- endcall -%}
 {% endmacro %}

--- a/dbt/include/fabric/macros/adapters/metadata.sql
+++ b/dbt/include/fabric/macros/adapters/metadata.sql
@@ -21,7 +21,7 @@
 {% endmacro %}
 
 {%- macro fabric__get_use_database_sql(database) -%}
-  USE [{{database | replace('"', '')}}];
+  USE [{{database | replace('"', '') | replace('[', '') | replace(']', '')}}];
 {%- endmacro -%}
 
 {% macro fabric__list_schemas(database) %}

--- a/dbt/include/fabric/macros/adapters/openrowset.sql
+++ b/dbt/include/fabric/macros/adapters/openrowset.sql
@@ -1,0 +1,189 @@
+{#
+    OPENROWSET support for Fabric Data Warehouse.
+    Enables file-based sources (Parquet, CSV, JSONL) from OneLake, ADLS, or Azure Blob Storage.
+    See: https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-bulk-transact-sql?view=fabric
+
+    Usage in models:
+      SELECT * FROM {{ openrowset_source('my_source', 'my_table') }}
+
+    Source definition in sources.yml:
+      sources:
+        - name: my_source
+          meta:
+            openrowset:
+              path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+          tables:
+            - name: my_parquet_table
+              meta:
+                openrowset:
+                  file: "data/sales.parquet"
+              columns:
+                - name: id
+                  data_type: int
+                - name: amount
+                  data_type: "decimal(10,2)"
+
+    Supported formats (Fabric Warehouse): PARQUET, CSV, JSONL
+    Note: DELTA format is NOT supported in Fabric Warehouse OPENROWSET.
+    Format is auto-detected from file extension, or can be set explicitly via meta.openrowset.format.
+
+    Format-specific defaults (user can override via meta.openrowset.options):
+      CSV:     HEADER_ROW = TRUE
+      PARQUET: no extra options needed
+      JSONL:   no extra options needed
+
+    Supported options per format:
+      CSV:     HEADER_ROW, FIELDTERMINATOR, ROWTERMINATOR, FIELDQUOTE, ESCAPECHAR,
+               PARSER_VERSION, FIRSTROW, LASTROW, CODEPAGE, DATAFILETYPE
+      PARQUET: ROWS_PER_BATCH, MAXERRORS, FIRSTROW, CODEPAGE, DATAFILETYPE
+      JSONL:   FIRSTROW, CODEPAGE, DATAFILETYPE, ROWS_PER_BATCH, MAXERRORS
+
+    Universal options (all formats): ROWS_PER_BATCH, MAXERRORS
+
+    WITH clause column mapping (column-level meta.openrowset):
+      path:    JSON path for JSONL/Parquet nested fields, e.g. "$.updated"
+      ordinal: Column position number for positional mapping
+#}
+
+{% macro openrowset_source(source_name, table_name) %}
+    {#-- Register the source dependency during parsing (graph not available yet) --#}
+    {%- set _src_relation = source(source_name, table_name) -%}
+    {%- if execute -%}
+        {{- adapter.dispatch('openrowset_source', 'dbt')(source_name, table_name) -}}
+    {%- endif -%}
+{% endmacro %}
+
+{% macro fabric__openrowset_source(source_name, table_name) %}
+    {#-- Resolve source node from the graph --#}
+    {%- set source_node = graph.sources.values()
+        | selectattr('source_name', 'equalto', source_name)
+        | selectattr('name', 'equalto', table_name)
+        | list -%}
+
+    {%- if source_node | length == 0 -%}
+        {%- do exceptions.raise_compiler_error(
+            "Source '" ~ source_name ~ "." ~ table_name ~ "' not found. "
+            ~ "Make sure it is defined in your sources.yml."
+        ) -%}
+    {%- endif -%}
+    {%- set source_node = source_node[0] -%}
+
+    {#-- Get openrowset config from table meta, then source meta --#}
+    {%- set table_meta = source_node.meta or {} -%}
+    {%- set table_openrowset = table_meta.get('openrowset', {}) -%}
+
+    {#-- Get parent source meta for shared config (e.g. base path) --#}
+    {%- set source_meta = source_node.source_meta or {} -%}
+    {%- set source_openrowset = source_meta.get('openrowset', {}) -%}
+
+    {#-- Build the full file path --#}
+    {%- set base_path = source_openrowset.get('path', '') -%}
+    {%- set file_path = table_openrowset.get('file', '') -%}
+    {%- set folder = table_openrowset.get('folder', '') -%}
+    {%- set full_path = table_openrowset.get('path', '') -%}
+
+    {%- if full_path -%}
+        {#-- Table-level path overrides everything --#}
+        {%- set bulk_path = full_path -%}
+    {%- elif base_path and (file_path or folder) -%}
+        {#-- Combine source base path + folder + file --#}
+        {%- set path_parts = [base_path.rstrip('/')] -%}
+        {%- if folder -%}
+            {%- do path_parts.append(folder.strip('/')) -%}
+        {%- endif -%}
+        {%- if file_path -%}
+            {%- do path_parts.append(file_path.strip('/')) -%}
+        {%- endif -%}
+        {%- set bulk_path = path_parts | join('/') -%}
+    {%- else -%}
+        {%- do exceptions.raise_compiler_error(
+            "OPENROWSET source '" ~ source_name ~ "." ~ table_name ~ "' requires a file path. "
+            ~ "Set 'path' in source-level meta.openrowset or 'file'/'path' in table-level meta.openrowset."
+        ) -%}
+    {%- endif -%}
+
+    {#-- Detect format from explicit config or file extension --#}
+    {%- set explicit_format = table_openrowset.get('format', source_openrowset.get('format', '')) -%}
+    {%- if explicit_format -%}
+        {%- set file_format = explicit_format | upper -%}
+    {%- else -%}
+        {%- set file_format = fabric__detect_format(bulk_path) -%}
+    {%- endif -%}
+
+    {#-- Get format-specific defaults --#}
+    {%- set format_defaults = fabric__openrowset_format_defaults(file_format) -%}
+
+    {#-- Merge: format defaults < source-level overrides < table-level overrides --#}
+    {%- set merged_options = {} -%}
+    {%- do merged_options.update(format_defaults) -%}
+    {%- set source_options = source_openrowset.get('options', {}) -%}
+    {%- set table_options = table_openrowset.get('options', {}) -%}
+    {%- do merged_options.update(source_options) -%}
+    {%- do merged_options.update(table_options) -%}
+
+    {#-- Build the OPENROWSET SQL --#}
+    {{ fabric__build_openrowset_sql(bulk_path, file_format, merged_options, source_node.columns, table_name) }}
+{%- endmacro %}
+
+
+{% macro fabric__detect_format(path) %}
+    {%- set path_lower = path | lower -%}
+    {%- if path_lower.endswith('.parquet') or path_lower.endswith('.parq') -%}
+        {{ return('PARQUET') }}
+    {%- elif path_lower.endswith('.csv') or path_lower.endswith('.tsv') -%}
+        {{ return('CSV') }}
+    {%- elif path_lower.endswith('.jsonl') or path_lower.endswith('.ldjson') or path_lower.endswith('.ndjson') -%}
+        {{ return('JSONL') }}
+    {%- else -%}
+        {%- do exceptions.raise_compiler_error(
+            "Cannot detect file format from path: '" ~ path ~ "'. "
+            ~ "Specify 'format' in meta.openrowset (one of: PARQUET, CSV, JSONL)."
+        ) -%}
+    {%- endif -%}
+{% endmacro %}
+
+
+{% macro fabric__openrowset_format_defaults(file_format) %}
+    {%- if file_format == 'CSV' -%}
+        {{ return({'HEADER_ROW': true}) }}
+    {%- elif file_format == 'PARQUET' -%}
+        {{ return({}) }}
+    {%- elif file_format == 'JSONL' -%}
+        {{ return({}) }}
+    {%- else -%}
+        {{ return({}) }}
+    {%- endif -%}
+{% endmacro %}
+
+
+{% macro fabric__build_openrowset_sql(bulk_path, file_format, options, columns, alias) %}
+    OPENROWSET(
+        BULK '{{ bulk_path }}',
+        FORMAT = '{{ file_format }}'
+        {#-- Render additional options --#}
+        {%- for key, value in options.items() %}
+            {%- if value is sameas true or value == 'True' or value == 'TRUE' %},
+        {{ key }} = TRUE
+            {%- elif value is sameas false or value == 'False' or value == 'FALSE' %},
+        {{ key }} = FALSE
+            {%- elif value is number %},
+        {{ key }} = {{ value }}
+            {%- else %},
+        {{ key }} = '{{ value }}'
+            {%- endif -%}
+        {%- endfor -%}
+    )
+    {#-- WITH clause for explicit column schema --#}
+    {%- if columns | length > 0 %}
+    WITH (
+        {%- for col_name, col_config in columns.items() %}
+        {%- set col_openrowset = (col_config.get('meta', {}) or {}).get('openrowset', {}) or {} %}
+        {{ col_name }} {{ col_config.data_type }}
+        {%- if col_openrowset.get('path') %} '{{ col_openrowset.path }}'{%- endif %}
+        {%- if col_openrowset.get('ordinal') %} {{ col_openrowset.ordinal }}{%- endif %}
+        {{- ', ' if not loop.last }}
+        {%- endfor %}
+    )
+    {%- endif %}
+    AS [{{ alias }}]
+{%- endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -4,11 +4,15 @@
     {% do adapter.drop_relation(tmp_vw_relation) %}
     {{ get_create_view_as_sql(tmp_vw_relation, sql) }}
 
+    {# Build CLUSTER BY clause - only for non-temporary tables #}
+    {% set cluster_by_clause = fabric__build_cluster_by_clause(temporary) %}
+
     {% set contract_config = config.get('contract') %}
     {% if contract_config.enforced %}
 
         CREATE TABLE {{relation}}
         {{ build_columns_constraints(relation) }}
+        {{ cluster_by_clause }}
         {{ get_assert_columns_equivalent(sql)  }}
         {% set listColumns %}
             {% for column in model['columns'] %}
@@ -21,14 +25,55 @@
             SELECT {{listColumns}} FROM {{tmp_vw_relation}} {{ query_label }}
         {% endif %}
 
-
     {%- else %}
         {%- set query_label_option = query_label.replace("'", "''") -%}
         {% if adapter.behavior.empty.no_warn %}
-            EXEC('CREATE TABLE {{relation}} AS SELECT * FROM {{tmp_vw_relation}} WHERE 0=1 {{ query_label_option }}');
+            EXEC('CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} WHERE 0=1 {{ query_label_option }}');
         {% else %}
-            EXEC('CREATE TABLE {{relation}} AS SELECT * FROM {{tmp_vw_relation}} {{ query_label_option }}');
+            EXEC('CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} {{ query_label_option }}');
         {% endif %}
-
     {% endif %}
+
+{% endmacro %}
+
+{#
+    Builds a WITH (CLUSTER BY (...)) clause for Fabric Data Warehouse tables.
+    See: https://learn.microsoft.com/en-us/fabric/data-warehouse/data-clustering
+
+    Limitations enforced:
+      - Maximum of 4 columns allowed in CLUSTER BY.
+      - Skipped for temporary tables (clustering is only applied at final table creation).
+      - Clustering must be defined at table creation; it cannot be added to existing tables via ALTER.
+      - Supported column types: bigint, int, smallint, decimal, numeric, float, real,
+        date, datetime2, time, char, varchar. Columns of unsupported types (bit, varchar(max),
+        varbinary, uniqueidentifier) cannot be used in CLUSTER BY.
+      - IDENTITY columns cannot be used with CLUSTER BY.
+
+    Config usage:
+      - Model level:  {{ config(cluster_by=['col1', 'col2']) }}
+      - Project level: +cluster_by: ['col1', 'col2']
+      - Single column shorthand: {{ config(cluster_by='col1') }}
+#}
+{% macro fabric__build_cluster_by_clause(temporary) %}
+    {%- set cluster_by = config.get('cluster_by') -%}
+    {%- if cluster_by is not none and not temporary -%}
+        {%- if cluster_by is string -%}
+            {%- set cluster_by = [cluster_by] -%}
+        {%- endif -%}
+
+        {%- if cluster_by | length < 1 -%}
+            {%- do exceptions.raise_compiler_error(
+                "CLUSTER BY requires at least one column."
+            ) -%}
+        {%- endif -%}
+
+        {%- if cluster_by | length > 4 -%}
+            {%- do exceptions.raise_compiler_error(
+                "Fabric Data Warehouse supports a maximum of 4 columns in CLUSTER BY. Got "
+                ~ cluster_by | length ~ " columns: " ~ cluster_by | join(', ') ~ "."
+            ) -%}
+        {%- endif -%}
+
+        WITH (CLUSTER BY ({{ cluster_by | join(', ') }}))
+    {%- endif -%}
 {% endmacro %}

--- a/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
@@ -6,7 +6,7 @@
 {% macro fabric__create_columns(relation, columns) %}
   {% for column in columns %}
     {% call statement() %}
-      alter table {{ relation.render() }} add "{{ column.name }}" {{ column.data_type }} NULL;
+      alter table {{ relation.render() }} add [{{ column.name }}] {{ column.data_type }} NULL;
     {% endcall %}
   {% endfor %}
 {% endmacro %}

--- a/docs/openrowset.md
+++ b/docs/openrowset.md
@@ -1,0 +1,872 @@
+# OPENROWSET Source — File-Based Ingestion for Fabric Data Warehouse
+
+The `dbt-fabric` adapter provides native [`OPENROWSET(BULK ...)`](https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-bulk-transact-sql?view=fabric) support, enabling you to query files directly from OneLake, Azure Data Lake Storage (ADLS Gen2), or Azure Blob Storage without loading them into a table first.
+
+This is useful for:
+
+- **ELT ingestion** — read raw files from a Lakehouse into staging models
+- **Data exploration** — query file contents ad-hoc without creating external tables
+- **Cross-workspace loads** — read files from other Fabric workspaces via OneLake
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Supported Formats](#supported-formats)
+- [Path Configuration](#path-configuration)
+  - [Source-Level Base Path](#source-level-base-path)
+  - [Table-Level File Reference](#table-level-file-reference)
+  - [Path Resolution Rules](#path-resolution-rules)
+  - [Supported Storage Locations](#supported-storage-locations)
+- [Wildcards and Folder Reads](#wildcards-and-folder-reads)
+- [Format Detection](#format-detection)
+- [Format Options](#format-options)
+  - [CSV Options](#csv-options)
+  - [Parquet Options](#parquet-options)
+  - [JSONL Options](#jsonl-options)
+  - [Option Override Hierarchy](#option-override-hierarchy)
+- [Column Schema (WITH Clause)](#column-schema-with-clause)
+  - [Basic Column Definitions](#basic-column-definitions)
+  - [Column Path Mapping (JSON / Nested Fields)](#column-path-mapping-json--nested-fields)
+  - [Column Ordinal Mapping](#column-ordinal-mapping)
+  - [Schema Inference (No WITH Clause)](#schema-inference-no-with-clause)
+- [Complete Examples](#complete-examples)
+  - [Parquet from OneLake](#parquet-from-onelake)
+  - [CSV with Default Options](#csv-with-default-options)
+  - [CSV with Custom Delimiter](#csv-with-custom-delimiter)
+  - [TSV (Tab-Separated)](#tsv-tab-separated)
+  - [JSONL with Nested Fields](#jsonl-with-nested-fields)
+  - [Parquet without Schema (Auto-Detect)](#parquet-without-schema-auto-detect)
+  - [External Storage (Azure Blob)](#external-storage-azure-blob)
+  - [Multiple Tables from One Source](#multiple-tables-from-one-source)
+- [Permissions](#permissions)
+- [Limitations](#limitations)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Quick Start
+
+### 1. Define a source in your `sources.yml`
+
+```yaml
+sources:
+  - name: my_lakehouse
+    meta:
+      openrowset:
+        path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+    tables:
+      - name: sales
+        meta:
+          openrowset:
+            file: "data/sales.parquet"
+        columns:
+          - name: id
+            data_type: int
+          - name: amount
+            data_type: "decimal(10,2)"
+          - name: sale_date
+            data_type: date
+```
+
+### 2. Use it in a model
+
+```sql
+-- models/stg_sales.sql
+SELECT *
+FROM {{ openrowset_source('my_lakehouse', 'sales') }}
+```
+
+### 3. Compiled SQL
+
+dbt compiles a model to the following SQL:
+
+```sql
+SELECT *
+FROM OPENROWSET(
+    BULK 'https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files/data/sales.parquet',
+    FORMAT = 'PARQUET'
+)
+WITH (
+    id int,
+    amount decimal(10,2),
+    sale_date date
+)
+AS [sales]
+```
+
+---
+
+## Supported Formats
+
+| Format    | Auto-Detected Extensions                 | Notes                                          |
+|-----------|------------------------------------------|-------------------------------------------------|
+| `PARQUET` | `.parquet`, `.parq`                      | Schema inference available; WITH clause optional |
+| `CSV`     | `.csv`, `.tsv`                           | Default: `HEADER_ROW = TRUE`                    |
+| `JSONL`   | `.jsonl`, `.ldjson`, `.ndjson`           | Newline-delimited JSON only                     |
+
+> **Important:** DELTA format is **not** supported in Fabric Warehouse `OPENROWSET`. Use Lakehouse tables or shortcuts instead.
+
+---
+
+## Path Configuration
+
+File paths are configured via `meta.openrowset` at both the **source** level and **table** level in your `sources.yml`.
+
+### Source-Level Base Path
+
+Set a shared base path for all tables in the source. This is typically the root of your Lakehouse Files folder or a storage container.
+
+```yaml
+sources:
+  - name: my_lakehouse
+    meta:
+      openrowset:
+        path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+```
+
+### Table-Level File Reference
+
+Each table specifies its file location relative to the source base path. You have three options:
+
+| Key      | Description                                              | Example                          |
+|----------|----------------------------------------------------------|----------------------------------|
+| `file`   | Relative file path, appended to source `path`            | `"data/sales.parquet"`           |
+| `folder` | Relative folder path, appended to source `path`          | `"data/sales"`                   |
+| `path`   | Full absolute URL — overrides source `path` entirely     | `"https://.../.../file.parquet"` |
+
+```yaml
+tables:
+  # Using 'file' — appended to source path
+  - name: sales
+    meta:
+      openrowset:
+        file: "data/sales.parquet"
+
+  # Using 'folder' — reads all files in a folder
+  - name: all_orders
+    meta:
+      openrowset:
+        folder: "data/orders"
+        format: PARQUET
+
+  # Using 'path' — full URL, ignores source base path entirely
+  - name: external_data
+    meta:
+      openrowset:
+        path: "https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/latest/data.parquet"
+```
+
+### Path Resolution Rules
+
+The macro resolves the final `BULK` path as follows:
+
+1. If table-level `path` is set → use it as-is (full override)
+2. If source-level `path` + table-level `file` or `folder` → concatenate them with `/`
+3. If neither is provided → compilation error
+
+When both `folder` and `file` are set, they are concatenated: `<source path>/<folder>/<file>`.
+
+### Supported Storage Locations
+
+| Storage                     | URL Format                                                                      |
+|-----------------------------|---------------------------------------------------------------------------------|
+| **OneLake (Fabric)**        | `https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files/...` |
+| **Azure Blob Storage**      | `https://<account>.blob.core.windows.net/<container>/...`                        |
+| **ADLS Gen2 (https)**       | `https://<account>.dfs.core.windows.net/<container>/...`                         |
+| **ADLS Gen2 (abfss)**       | `abfss://<container>@<account>.dfs.core.windows.net/...`                         |
+
+> For OneLake paths, use `dfs.fabric.microsoft.com` (not `blob`). 
+
+---
+
+## Wildcards and Folder Reads
+
+`OPENROWSET` supports reading multiple files at once using wildcards or folder paths. This works for all formats.
+
+```yaml
+tables:
+  # Wildcard pattern — format auto-detected from *.parquet extension
+  - name: partitioned_sales
+    meta:
+      openrowset:
+        file: "data/year=2024/*.parquet"
+    columns:
+      - name: id
+        data_type: int
+      - name: amount
+        data_type: "decimal(10,2)"
+
+  # Recursive traversal — explicit format required (no file extension to detect from)
+  - name: all_logs
+    meta:
+      openrowset:
+        folder: "logs/**"
+        format: CSV
+    columns:
+      - name: timestamp
+        data_type: datetime2
+      - name: message
+        data_type: "varchar(8000)"
+
+  # Bare folder — explicit format required
+  - name: events
+    meta:
+      openrowset:
+        folder: "data/events"
+        format: JSONL
+```
+
+> **Rule:** When the path ends with a recognized file extension (`.parquet`, `.csv`, `.jsonl`, etc.), the format is auto-detected. When the path is a bare folder or uses `/**`, you must set `format` explicitly.
+
+You can use the `filepath()` and `filename()` functions in your model SQL to filter or partition data:
+
+```sql
+-- models/stg_sales_2024.sql
+SELECT
+    sales.filepath(1) AS year_partition,
+    sales.*
+FROM {{ openrowset_source('my_lakehouse', 'partitioned_sales') }} AS sales
+WHERE sales.filepath(1) = '2024'
+```
+
+---
+
+## Format Detection
+
+The macro auto-detects the file format from the path's file extension:
+
+| Extension(s)                        | Detected Format |
+|-------------------------------------|-----------------|
+| `.parquet`, `.parq`                 | `PARQUET`       |
+| `.csv`, `.tsv`                      | `CSV`           |
+| `.jsonl`, `.ldjson`, `.ndjson`      | `JSONL`         |
+
+To override auto-detection (e.g., for files with non-standard extensions), set `format` explicitly:
+
+```yaml
+tables:
+  - name: custom_file
+    meta:
+      openrowset:
+        file: "data/export.txt"
+        format: CSV    # Force CSV format for a .txt file
+```
+
+---
+
+## Format Options
+
+Options are set in `meta.openrowset.options` at the source or table level. All options are passed directly to the `OPENROWSET` function.
+
+### CSV Options
+
+CSV sources automatically default to `HEADER_ROW = TRUE`. All other options use Fabric engine defaults unless you override them.
+
+| Option             | Default (dbt-fabric)     | Engine Default               | Description                                       |
+|--------------------|--------------------------|------------------------------|---------------------------------------------------|
+| `HEADER_ROW`       | `TRUE`                   | `FALSE`                      | Whether the first row is a header row              |
+| `FIELDTERMINATOR`  | *(not set)*              | `,` (comma)                  | Field delimiter character                          |
+| `ROWTERMINATOR`    | *(not set)*              | `\r\n` (CRLF)               | Row delimiter character                            |
+| `FIELDQUOTE`       | *(not set)*              | `"` (double quote)           | Quote character for enclosing fields               |
+| `ESCAPECHAR`       | *(not set)*              | *(none)*                     | Escape character for special characters            |
+| `PARSER_VERSION`   | *(not set)*              | `2.0`                        | CSV parser version: `'1.0'` or `'2.0'`            |
+| `FIRSTROW`         | *(not set)*              | `1`                          | First row number to read (1-based)                 |
+| `LASTROW`          | *(not set)*              | *(end of file)*              | Last row number to read                            |
+| `CODEPAGE`         | *(not set)*              | `OEM`                        | `'ACP'`, `'OEM'`, `'RAW'`, or a code page number  |
+| `DATAFILETYPE`     | *(not set)*              | `char`                       | `'char'` (single-byte) or `'widechar'` (UTF-16)   |
+
+**CSV parser version notes:**
+
+- **Parser 2.0** (default): Optimized for performance. Max column length 8000 chars. Max row size 8 MB. Does not support `DATA_COMPRESSION`.
+- **Parser 1.0**: Supports all options and encodings. Does **not** support `HEADER_ROW`. Auto-fallback occurs when using 1.0-only options.
+
+Example with custom CSV options:
+
+```yaml
+tables:
+  - name: products
+    meta:
+      openrowset:
+        file: "products_semicolon.csv"
+        options:
+          FIELDTERMINATOR: ";"
+          FIELDQUOTE: '"'
+          PARSER_VERSION: "2.0"
+    columns:
+      - name: product_id
+        data_type: int
+      - name: name
+        data_type: "varchar(200)"
+      - name: price
+        data_type: "decimal(10,2)"
+```
+
+### Parquet Options
+
+Parquet files typically need no additional options. The engine reads the schema from the file metadata.
+
+| Option             | Description                                          |
+|--------------------|------------------------------------------------------|
+| `FIRSTROW`         | First row number to read                             |
+| `ROWS_PER_BATCH`   | Approximate rows per batch (performance hint)        |
+| `MAXERRORS`         | Max formatting errors before failure (default: 10)   |
+| `CODEPAGE`         | Code page for character data                         |
+| `DATAFILETYPE`     | `'char'` or `'widechar'`                             |
+
+### JSONL Options
+
+JSONL (newline-delimited JSON) files require each line to be a valid JSON document. The newline character is the record separator and cannot appear within a JSON document.
+
+| Option             | Description                                          |
+|--------------------|------------------------------------------------------|
+| `FIRSTROW`         | First row number to read                             |
+| `ROWS_PER_BATCH`   | Approximate rows per batch (performance hint)        |
+| `MAXERRORS`         | Max formatting errors before failure (default: 10)   |
+| `CODEPAGE`         | Code page for character data                         |
+| `DATAFILETYPE`     | `'char'` or `'widechar'`                             |
+
+### Option Override Hierarchy
+
+Options merge in this order (last wins):
+
+1. **Format defaults** — CSV gets `HEADER_ROW = TRUE`; Parquet and JSONL have no defaults
+2. **Source-level** `meta.openrowset.options` — shared across all tables in the source
+3. **Table-level** `meta.openrowset.options` — specific to one table
+
+```yaml
+sources:
+  - name: shared_csv_source
+    meta:
+      openrowset:
+        path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+        options:
+          PARSER_VERSION: "2.0"          # applies to all tables in this source
+    tables:
+      - name: standard_csv
+        meta:
+          openrowset:
+            file: "data/standard.csv"
+            # Inherits: HEADER_ROW=TRUE (format default), PARSER_VERSION='2.0' (source)
+
+      - name: semicolon_csv
+        meta:
+          openrowset:
+            file: "data/semicolon.csv"
+            options:
+              FIELDTERMINATOR: ";"        # table-level override
+              # Inherits: HEADER_ROW=TRUE (format default), PARSER_VERSION='2.0' (source)
+
+      - name: no_header_csv
+        meta:
+          openrowset:
+            file: "data/raw.csv"
+            options:
+              HEADER_ROW: false           # overrides the format default
+              FIRSTROW: 1
+```
+
+To disable the `HEADER_ROW = TRUE` default, explicitly set `HEADER_ROW: false` at the table level.
+
+---
+
+## Column Schema (WITH Clause)
+
+### Basic Column Definitions
+
+Define columns in your source table's `columns` list. Each column needs a `name` and `data_type`. These generate the `WITH (...)` clause in the compiled SQL.
+
+```yaml
+columns:
+  - name: customer_id
+    data_type: int
+  - name: first_name
+    data_type: "varchar(100)"
+  - name: amount
+    data_type: "decimal(10,2)"
+  - name: created_at
+    data_type: datetime2
+```
+
+Compiled output:
+
+```sql
+WITH (
+    customer_id int,
+    first_name varchar(100),
+    amount decimal(10,2),
+    created_at datetime2
+)
+```
+
+Common Fabric Warehouse data types for the WITH clause: `int`, `bigint`, `smallint`, `tinyint`, `bit`, `float`, `real`, `decimal(p,s)`, `numeric(p,s)`, `money`, `date`, `time`, `datetime2`, `datetimeoffset`, `varchar(n)`, `nvarchar(n)`, `char(n)`, `varbinary(n)`, `uniqueidentifier`.
+
+### Column Path Mapping (JSON / Nested Fields)
+
+For JSONL files or Parquet files with nested/complex types, use `meta.openrowset.path` on individual columns to specify a JSON path expression.
+
+```yaml
+columns:
+  - name: event_id
+    data_type: "varchar(50)"
+
+  - name: event_date
+    data_type: DATE
+    meta:
+      openrowset:
+        path: "$.updated"          # Maps to a different JSON property name
+
+  - name: user_id
+    data_type: INT
+    meta:
+      openrowset:
+        path: "$.user.id"          # Nested object access
+
+  - name: fatal_cases
+    data_type: INT
+    meta:
+      openrowset:
+        path: "$.statistics.deaths"  # Deeply nested property
+```
+
+Compiled output:
+
+```sql
+WITH (
+    event_id varchar(50),
+    event_date DATE '$.updated',
+    user_id INT '$.user.id',
+    fatal_cases INT '$.statistics.deaths'
+)
+```
+
+### Column Ordinal Mapping
+
+Use `meta.openrowset.ordinal` to bind a column by its position (1-based) in the file rather than by name.
+
+```yaml
+columns:
+  - name: cases
+    data_type: INT
+    meta:
+      openrowset:
+        ordinal: 3                  # Maps to the 3rd column in the file
+```
+
+Compiled output:
+
+```sql
+WITH (
+    cases INT 3
+)
+```
+
+### Schema Inference (No WITH Clause)
+
+For Parquet files, you can omit the `columns` list entirely. The engine will infer the schema from the Parquet file metadata. This does **not** work for CSV or JSONL.
+
+```yaml
+tables:
+  - name: customers_auto
+    meta:
+      openrowset:
+        file: "customers.parquet"
+    # No columns defined — engine auto-detects schema
+```
+
+Compiled output:
+
+```sql
+OPENROWSET(
+    BULK '...',
+    FORMAT = 'PARQUET'
+)
+AS [customers_auto]
+```
+
+> **Note:** Schema inference returns all columns from the file. For production models, define explicit column schemas to control data types and filter columns.
+
+---
+
+## Complete Examples
+
+### Parquet from OneLake
+
+```yaml
+# sources.yml
+sources:
+  - name: my_lakehouse
+    meta:
+      openrowset:
+        path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+    tables:
+      - name: customers
+        meta:
+          openrowset:
+            file: "customers.parquet"
+        columns:
+          - name: customer_id
+            data_type: int
+          - name: first_name
+            data_type: "varchar(100)"
+          - name: last_name
+            data_type: "varchar(100)"
+          - name: email
+            data_type: "varchar(200)"
+          - name: created_at
+            data_type: datetime2
+```
+
+```sql
+-- models/stg_customers.sql
+SELECT * FROM {{ openrowset_source('my_lakehouse', 'customers') }}
+```
+
+**Compiled SQL:**
+
+```sql
+SELECT * FROM OPENROWSET(
+    BULK 'https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files/customers.parquet',
+    FORMAT = 'PARQUET'
+)
+WITH (
+    customer_id int,
+    first_name varchar(100),
+    last_name varchar(100),
+    email varchar(200),
+    created_at datetime2
+)
+AS [customers]
+```
+
+### CSV with Default Options
+
+```yaml
+tables:
+  - name: orders
+    meta:
+      openrowset:
+        file: "orders.csv"
+    columns:
+      - name: order_id
+        data_type: int
+      - name: customer_id
+        data_type: int
+      - name: order_date
+        data_type: date
+      - name: amount
+        data_type: "decimal(10,2)"
+      - name: status
+        data_type: "varchar(50)"
+```
+
+**Compiled SQL:**
+
+```sql
+SELECT * FROM OPENROWSET(
+    BULK '...Files/orders.csv',
+    FORMAT = 'CSV',
+    HEADER_ROW = TRUE
+)
+WITH (
+    order_id int,
+    customer_id int,
+    order_date date,
+    amount decimal(10,2),
+    status varchar(50)
+)
+AS [orders]
+```
+
+### CSV with Custom Delimiter
+
+```yaml
+tables:
+  - name: products
+    meta:
+      openrowset:
+        file: "products_semicolon.csv"
+        options:
+          FIELDTERMINATOR: ";"
+    columns:
+      - name: product_id
+        data_type: int
+      - name: name
+        data_type: "varchar(200)"
+      - name: category
+        data_type: "varchar(100)"
+      - name: price
+        data_type: "decimal(10,2)"
+      - name: in_stock
+        data_type: bit
+```
+
+**Compiled SQL:**
+
+```sql
+SELECT * FROM OPENROWSET(
+    BULK '...Files/products_semicolon.csv',
+    FORMAT = 'CSV',
+    HEADER_ROW = TRUE,
+    FIELDTERMINATOR = ';'
+)
+WITH (
+    product_id int,
+    name varchar(200),
+    category varchar(100),
+    price decimal(10,2),
+    in_stock bit
+)
+AS [products]
+```
+
+### TSV (Tab-Separated)
+
+`.tsv` files are auto-detected as CSV format. Set the tab delimiter explicitly:
+
+```yaml
+tables:
+  - name: orders_tsv
+    meta:
+      openrowset:
+        file: "orders.tsv"
+        options:
+          FIELDTERMINATOR: "\t"
+    columns:
+      - name: order_id
+        data_type: int
+      - name: customer_id
+        data_type: int
+      - name: order_date
+        data_type: date
+      - name: amount
+        data_type: "decimal(10,2)"
+      - name: status
+        data_type: "varchar(50)"
+```
+
+### JSONL with Nested Fields
+
+```yaml
+tables:
+  - name: events
+    meta:
+      openrowset:
+        file: "events.jsonl"
+    columns:
+      - name: event_id
+        data_type: "varchar(50)"
+      - name: event_type
+        data_type: "varchar(50)"
+      - name: timestamp
+        data_type: "varchar(50)"
+      - name: user_id
+        data_type: INT
+        meta:
+          openrowset:
+            path: "$.user.id"
+      - name: user_name
+        data_type: "varchar(100)"
+        meta:
+          openrowset:
+            path: "$.user.name"
+      - name: page
+        data_type: "varchar(200)"
+        meta:
+          openrowset:
+            path: "$.properties.page"
+```
+
+**Compiled SQL:**
+
+```sql
+SELECT * FROM OPENROWSET(
+    BULK '...Files/events.jsonl',
+    FORMAT = 'JSONL'
+)
+WITH (
+    event_id varchar(50),
+    event_type varchar(50),
+    timestamp varchar(50),
+    user_id INT '$.user.id',
+    user_name varchar(100) '$.user.name',
+    page varchar(200) '$.properties.page'
+)
+AS [events]
+```
+
+### Parquet without Schema (Auto-Detect)
+
+```yaml
+tables:
+  - name: customers_auto
+    meta:
+      openrowset:
+        file: "customers.parquet"
+```
+
+```sql
+-- models/explore_customers.sql
+SELECT TOP 100 * FROM {{ openrowset_source('my_lakehouse', 'customers_auto') }}
+```
+
+**Compiled SQL:**
+
+```sql
+SELECT TOP 100 * FROM OPENROWSET(
+    BULK '...Files/customers.parquet',
+    FORMAT = 'PARQUET'
+)
+AS [customers_auto]
+```
+
+### External Storage (Azure Blob)
+
+Use a full `path` at the table level to read from storage outside your Lakehouse:
+
+```yaml
+sources:
+  - name: external_blob
+    tables:
+      - name: covid_data
+        meta:
+          openrowset:
+            path: "https://pandemicdatalake.blob.core.windows.net/public/curated/covid-19/bing_covid-19_data/latest/bing_covid-19_data.parquet"
+        columns:
+          - name: id
+            data_type: int
+          - name: confirmed
+            data_type: int
+          - name: deaths
+            data_type: int
+          - name: country_region
+            data_type: "varchar(200)"
+```
+
+### Multiple Tables from One Source
+
+Define a shared base path once and reference multiple files:
+
+```yaml
+sources:
+  - name: my_lakehouse
+    meta:
+      openrowset:
+        path: "https://onelake.dfs.fabric.microsoft.com/<workspaceId>/<lakehouseId>/Files"
+    tables:
+      - name: customers
+        meta:
+          openrowset:
+            file: "customers.parquet"
+        columns:
+          - name: customer_id
+            data_type: int
+          - name: first_name
+            data_type: "varchar(100)"
+          - name: last_name
+            data_type: "varchar(100)"
+
+      - name: orders
+        meta:
+          openrowset:
+            file: "orders.csv"
+        columns:
+          - name: order_id
+            data_type: int
+          - name: customer_id
+            data_type: int
+          - name: amount
+            data_type: "decimal(10,2)"
+
+      - name: events
+        meta:
+          openrowset:
+            file: "events.jsonl"
+        columns:
+          - name: event_id
+            data_type: "varchar(50)"
+          - name: event_type
+            data_type: "varchar(50)"
+```
+
+```sql
+-- models/stg_customers.sql
+SELECT * FROM {{ openrowset_source('my_lakehouse', 'customers') }}
+
+-- models/stg_orders.sql
+SELECT * FROM {{ openrowset_source('my_lakehouse', 'orders') }}
+
+-- models/stg_events.sql
+SELECT * FROM {{ openrowset_source('my_lakehouse', 'events') }}
+```
+
+---
+
+## Permissions
+
+The executing principal requires:
+
+| Permission                               | Scope                                           |
+|------------------------------------------|-------------------------------------------------|
+| `ADMINISTER DATABASE BULK OPERATIONS`    | On the Fabric Warehouse                         |
+| **Storage Blob Data Reader** (or higher) | On the target storage account/container          |
+
+For **OneLake** paths within the same Fabric tenant, permissions are enforced via Microsoft Entra ID passthrough — no additional storage role is needed if the user has Fabric workspace access.
+
+Grant the bulk operations permission:
+
+```sql
+GRANT ADMINISTER DATABASE BULK OPERATIONS TO [user@domain.com];
+```
+
+---
+
+## Limitations
+
+- **DELTA format** is not supported in Fabric Warehouse `OPENROWSET`. Use Lakehouse tables or shortcuts.
+- **Schema inference** (omitting the WITH clause) only works for **Parquet** files. CSV and JSONL require explicit column definitions.
+- **CSV Parser 2.0** has a max column length of 8,000 characters and max row size of 8 MB.
+- **CSV Parser 1.0** does not support `HEADER_ROW`.
+- **JSONL** files must use newlines as record separators. Newlines within a JSON document are not allowed.
+- `SINGLE_BLOB`, `SINGLE_CLOB`, and `SINGLE_NCLOB` options are not supported in Fabric Warehouse.
+- The `DATA_SOURCE` option (named external data sources) is not supported in Fabric Warehouse — use full absolute URIs.
+- File paths must be absolute URLs. Relative paths are only supported with `DATA_SOURCE`, which is not available in Fabric Warehouse.
+
+---
+
+## Troubleshooting
+
+### "Cannot detect file format from path"
+
+The file extension is not recognized. Set `format` explicitly:
+
+```yaml
+meta:
+  openrowset:
+    file: "data/export.txt"
+    format: CSV
+```
+
+### "OPENROWSET source requires a file path"
+
+Neither a table-level `file`/`folder`/`path` nor a source-level `path` was configured. Ensure your source has a base `path` and your table has a `file` or `folder`.
+
+### "Source not found"
+
+The source name and table name in `openrowset_source('source_name', 'table_name')` must match exactly what's defined in `sources.yml`.
+
+### Permission errors (403 / Access Denied)
+
+- Verify the executing user has `ADMINISTER DATABASE BULK OPERATIONS`
+- For non-OneLake storage, ensure the user has **Storage Blob Data Reader** on the storage account
+- For OneLake, verify workspace access in Fabric
+
+### "TCP Provider: Error code 0x2746"
+
+This is a connection error, not related to OPENROWSET. Check your Fabric Warehouse connection settings in `profiles.yml`.
+
+### Column type mismatch errors
+
+Ensure the `data_type` in your column definitions matches the actual data in the file. Common issues:
+- Using `date` for a column that contains datetime values → use `datetime2`
+- Using `int` for values that exceed int range → use `bigint`
+- Not specifying length for `varchar` → use `varchar(n)` with an appropriate length

--- a/tests/functional/adapter/test_cluster_by.py
+++ b/tests/functional/adapter/test_cluster_by.py
@@ -1,0 +1,246 @@
+import re
+
+import pytest
+from dbt.tests.util import read_file, run_dbt, run_dbt_and_capture
+
+# -- Model fixtures --
+
+cluster_by_table_model_sql = """
+{{ config(
+    materialized='table',
+    cluster_by=['id', 'order_date']
+) }}
+
+select 1 as id, cast('2024-01-01' as date) as order_date, 100.00 as amount
+"""
+
+cluster_by_single_column_model_sql = """
+{{ config(
+    materialized='table',
+    cluster_by='id'
+) }}
+
+select 1 as id, cast('2024-01-01' as date) as order_date
+"""
+
+cluster_by_incremental_model_sql = """
+{{ config(
+    materialized='incremental',
+    cluster_by=['id', 'order_date']
+) }}
+
+select 1 as id, cast('2024-01-01' as date) as order_date, 100.00 as amount
+"""
+
+cluster_by_too_many_columns_model_sql = """
+{{ config(
+    materialized='table',
+    cluster_by=['col1', 'col2', 'col3', 'col4', 'col5']
+) }}
+
+select 1 as col1, 2 as col2, 3 as col3, 4 as col4, 5 as col5
+"""
+
+cluster_by_max_columns_model_sql = """
+{{ config(
+    materialized='table',
+    cluster_by=['col1', 'col2', 'col3', 'col4']
+) }}
+
+select 1 as col1, 2 as col2, 3 as col3, 4 as col4
+"""
+
+no_cluster_by_model_sql = """
+{{ config(materialized='table') }}
+
+select 1 as id, cast('2024-01-01' as date) as order_date
+"""
+
+cluster_by_contract_model_sql = """
+{{ config(
+    materialized='table',
+    cluster_by=['id', 'order_date'],
+    contract={'enforced': true}
+) }}
+
+select 1 as id, cast('2024-01-01' as date) as order_date, 100.00 as amount
+"""
+
+cluster_by_contract_schema_yml = """
+version: 2
+models:
+  - name: cluster_by_contract_model
+    config:
+      contract:
+        enforced: true
+      cluster_by:
+        - id
+        - order_date
+    columns:
+      - name: id
+        data_type: int
+      - name: order_date
+        data_type: date
+      - name: amount
+        data_type: "decimal(10,2)"
+"""
+
+
+def _normalize_whitespace(input: str) -> str:
+    subbed = re.sub(r"\s+", " ", input)
+    return re.sub(r"\s?([\(\),])\s?", r"\1", subbed).lower().strip()
+
+
+class TestClusterByTable:
+    """Test CLUSTER BY clause in table materialization (CTAS path)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_model.sql": cluster_by_table_model_sql,
+        }
+
+    def test__cluster_by_in_generated_sql(self, project):
+        results = run_dbt(["run", "-s", "cluster_by_model"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "cluster_by_model.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        assert "with(cluster by(id,order_date))" in normalized
+
+
+class TestClusterBySingleColumn:
+    """Test CLUSTER BY with a single column string shorthand."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_single.sql": cluster_by_single_column_model_sql,
+        }
+
+    def test__cluster_by_single_column(self, project):
+        results = run_dbt(["run", "-s", "cluster_by_single"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "cluster_by_single.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        assert "with(cluster by(id))" in normalized
+
+
+class TestClusterByIncremental:
+    """Test CLUSTER BY in incremental materialization (full refresh creates new table)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_incremental.sql": cluster_by_incremental_model_sql,
+        }
+
+    def test__cluster_by_incremental_full_refresh(self, project):
+        # First run = full refresh (new table), should have CLUSTER BY
+        results = run_dbt(["run", "-s", "cluster_by_incremental"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "cluster_by_incremental.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        assert "with(cluster by(id,order_date))" in normalized
+
+    def test__cluster_by_incremental_merge_no_cluster(self, project):
+        # First run creates the table
+        run_dbt(["run", "-s", "cluster_by_incremental"])
+
+        # Second run is incremental merge — temp table should NOT have CLUSTER BY
+        results = run_dbt(["run", "-s", "cluster_by_incremental"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "cluster_by_incremental.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        # The incremental path creates a temp table (temporary=True),
+        # so CLUSTER BY should not appear in the temp table creation
+        # but the main merge/insert statement should not add clustering either
+        assert "cluster by" not in normalized or "with(cluster by" not in normalized
+
+
+class TestClusterByTooManyColumns:
+    """Test that more than 4 columns raises a compiler error."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_too_many.sql": cluster_by_too_many_columns_model_sql,
+        }
+
+    def test__cluster_by_exceeds_max_columns(self, project):
+        results, log_output = run_dbt_and_capture(
+            ["run", "-s", "cluster_by_too_many"], expect_pass=False
+        )
+        assert len(results) == 1
+        assert "maximum of 4 columns" in log_output
+
+
+class TestClusterByMaxColumns:
+    """Test that exactly 4 columns (the maximum) works."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_max.sql": cluster_by_max_columns_model_sql,
+        }
+
+    def test__cluster_by_four_columns(self, project):
+        results = run_dbt(["run", "-s", "cluster_by_max"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "cluster_by_max.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        assert "with(cluster by(col1,col2,col3,col4))" in normalized
+
+
+class TestNoClusterBy:
+    """Test that without cluster_by config, no CLUSTER BY clause appears."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "no_cluster_model.sql": no_cluster_by_model_sql,
+        }
+
+    def test__no_cluster_by_clause(self, project):
+        results = run_dbt(["run", "-s", "no_cluster_model"])
+        assert len(results) == 1
+
+        generated_sql = read_file("target", "run", "test", "models", "no_cluster_model.sql")
+        normalized = _normalize_whitespace(generated_sql)
+
+        assert "cluster by" not in normalized
+
+
+class TestClusterByWithContract:
+    """Test CLUSTER BY combined with contract enforcement (CREATE TABLE + INSERT path)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "cluster_by_contract_model.sql": cluster_by_contract_model_sql,
+            "constraints_schema.yml": cluster_by_contract_schema_yml,
+        }
+
+    def test__cluster_by_with_contract(self, project):
+        results = run_dbt(["run", "-s", "cluster_by_contract_model"])
+        assert len(results) == 1
+
+        generated_sql = read_file(
+            "target", "run", "test", "models", "cluster_by_contract_model.sql"
+        )
+        normalized = _normalize_whitespace(generated_sql)
+
+        # Contract path: CREATE TABLE (columns) WITH (CLUSTER BY (...))
+        assert "with(cluster by(id,order_date))" in normalized
+        # Should also have the column definitions from the contract
+        assert "id int" in normalized
+        assert "order_date date" in normalized

--- a/tests/functional/adapter/test_openrowset.py
+++ b/tests/functional/adapter/test_openrowset.py
@@ -1,0 +1,478 @@
+import re
+
+import pytest
+from dbt.tests.util import read_file, run_dbt
+
+# -- Constants --
+
+ONELAKE_BASE = (
+    "https://msit-onelake.dfs.fabric.microsoft.com"
+    "/e4487eff-d67d-4b58-917c-ffbb61a5c05f"
+    "/08f6bf3d-0819-4d4d-bfbb-b04a2fab4238/Files"
+)
+SAMPLE_DATA_PATH = ONELAKE_BASE
+
+# -- Source definitions --
+
+sources_parquet_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: customers
+        meta:
+          openrowset:
+            file: "customers.parquet"
+        columns:
+          - name: customer_id
+            data_type: int
+          - name: first_name
+            data_type: "varchar(100)"
+          - name: last_name
+            data_type: "varchar(100)"
+          - name: email
+            data_type: "varchar(200)"
+          - name: created_at
+            data_type: datetime2
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_csv_orders_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: orders
+        meta:
+          openrowset:
+            file: "orders.csv"
+        columns:
+          - name: order_id
+            data_type: int
+          - name: customer_id
+            data_type: int
+          - name: order_date
+            data_type: date
+          - name: amount
+            data_type: "decimal(10,2)"
+          - name: status
+            data_type: "varchar(50)"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_csv_semicolon_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: products
+        meta:
+          openrowset:
+            file: "products_semicolon.csv"
+            options:
+              FIELDTERMINATOR: ";"
+        columns:
+          - name: product_id
+            data_type: int
+          - name: name
+            data_type: "varchar(200)"
+          - name: category
+            data_type: "varchar(100)"
+          - name: price
+            data_type: "decimal(10,2)"
+          - name: in_stock
+            data_type: bit
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_tsv_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: orders_tsv
+        meta:
+          openrowset:
+            file: "orders.tsv"
+            options:
+              FIELDTERMINATOR: "\\t"
+        columns:
+          - name: order_id
+            data_type: int
+          - name: customer_id
+            data_type: int
+          - name: order_date
+            data_type: date
+          - name: amount
+            data_type: "decimal(10,2)"
+          - name: status
+            data_type: "varchar(50)"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_jsonl_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: events
+        meta:
+          openrowset:
+            file: "events.jsonl"
+        columns:
+          - name: event_id
+            data_type: "varchar(50)"
+          - name: event_type
+            data_type: "varchar(50)"
+          - name: timestamp
+            data_type: "varchar(50)"
+          - name: user_id
+            data_type: INT
+            meta:
+              openrowset:
+                path: "$.user.id"
+          - name: user_name
+            data_type: "varchar(100)"
+            meta:
+              openrowset:
+                path: "$.user.name"
+          - name: page
+            data_type: "varchar(200)"
+            meta:
+              openrowset:
+                path: "$.properties.page"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_parquet_no_schema_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: customers_auto
+        meta:
+          openrowset:
+            file: "customers.parquet"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_explicit_format_yml = """
+version: 2
+sources:
+  - name: sample_data
+    meta:
+      openrowset:
+        path: "{base}"
+    tables:
+      - name: orders_explicit
+        meta:
+          openrowset:
+            file: "orders.csv"
+            format: CSV
+        columns:
+          - name: order_id
+            data_type: int
+          - name: customer_id
+            data_type: int
+          - name: order_date
+            data_type: date
+          - name: amount
+            data_type: "decimal(10,2)"
+          - name: status
+            data_type: "varchar(50)"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+sources_full_path_override_yml = """
+version: 2
+sources:
+  - name: direct_access
+    tables:
+      - name: customers_direct
+        meta:
+          openrowset:
+            path: "{base}/customers.parquet"
+        columns:
+          - name: customer_id
+            data_type: int
+          - name: first_name
+            data_type: "varchar(100)"
+""".format(
+    base=SAMPLE_DATA_PATH
+)
+
+# -- Model SQL fixtures --
+
+parquet_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'customers') }}
+"""
+
+csv_orders_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'orders') }}
+"""
+
+csv_semicolon_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'products') }}
+"""
+
+tsv_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'orders_tsv') }}
+"""
+
+jsonl_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'events') }}
+"""
+
+parquet_no_schema_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'customers_auto') }}
+"""
+
+explicit_format_model_sql = """
+SELECT * FROM {{ openrowset_source('sample_data', 'orders_explicit') }}
+"""
+
+full_path_model_sql = """
+SELECT * FROM {{ openrowset_source('direct_access', 'customers_direct') }}
+"""
+
+
+# -- Helpers --
+
+
+def _normalize(sql: str) -> str:
+    """Collapse whitespace and remove spaces around punctuation for easy assertion."""
+    s = re.sub(r"\s+", " ", sql)
+    return re.sub(r"\s?([\(\),])\s?", r"\1", s).lower().strip()
+
+
+# -- Test classes --
+
+
+class TestOpenrowsetParquet:
+    """Parquet file with explicit column schema."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "parquet_model.sql": parquet_model_sql,
+            "sources.yml": sources_parquet_yml,
+        }
+
+    def test__parquet_compiles(self, project):
+        results = run_dbt(["compile", "-s", "parquet_model"])
+        assert len(results) == 1
+
+        sql = _normalize(read_file("target", "compiled", "test", "models", "parquet_model.sql"))
+
+        assert "openrowset(" in sql
+        assert "bulk '{}/customers.parquet'".format(SAMPLE_DATA_PATH.lower()) in sql
+        assert "format = 'parquet'" in sql
+        assert "with(" in sql
+        assert "customer_id int" in sql
+        assert "first_name varchar(100)" in sql
+        assert "last_name varchar(100)" in sql
+        assert "email varchar(200)" in sql
+        assert "created_at datetime2" in sql
+        assert "as [customers]" in sql
+
+
+class TestOpenrowsetCsvOrders:
+    """CSV file with default options (HEADER_ROW = TRUE auto-applied)."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "csv_orders_model.sql": csv_orders_model_sql,
+            "sources.yml": sources_csv_orders_yml,
+        }
+
+    def test__csv_default_options(self, project):
+        results = run_dbt(["compile", "-s", "csv_orders_model"])
+        assert len(results) == 1
+
+        sql = _normalize(read_file("target", "compiled", "test", "models", "csv_orders_model.sql"))
+
+        assert "format = 'csv'" in sql
+        assert "header_row = true" in sql
+        # Engine defaults handle terminators — should not appear
+        assert "fieldterminator" not in sql
+        assert "rowterminator" not in sql
+        # Schema
+        assert "order_id int" in sql
+        assert "amount decimal(10,2)" in sql
+        assert "status varchar(50)" in sql
+        assert "as [orders]" in sql
+
+
+class TestOpenrowsetCsvSemicolon:
+    """CSV file with semicolon delimiter override."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "csv_semicolon_model.sql": csv_semicolon_model_sql,
+            "sources.yml": sources_csv_semicolon_yml,
+        }
+
+    def test__csv_semicolon_override(self, project):
+        results = run_dbt(["compile", "-s", "csv_semicolon_model"])
+        assert len(results) == 1
+
+        sql = _normalize(
+            read_file("target", "compiled", "test", "models", "csv_semicolon_model.sql")
+        )
+
+        assert "format = 'csv'" in sql
+        assert "header_row = true" in sql
+        assert "fieldterminator = ';'" in sql
+        assert "product_id int" in sql
+        assert "name varchar(200)" in sql
+        assert "price decimal(10,2)" in sql
+        assert "in_stock bit" in sql
+        assert "as [products]" in sql
+
+
+class TestOpenrowsetTsv:
+    """TSV file — auto-detected as CSV format with tab delimiter override."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "tsv_model.sql": tsv_model_sql,
+            "sources.yml": sources_tsv_yml,
+        }
+
+    def test__tsv_compiles(self, project):
+        results = run_dbt(["compile", "-s", "tsv_model"])
+        assert len(results) == 1
+
+        sql = _normalize(read_file("target", "compiled", "test", "models", "tsv_model.sql"))
+
+        assert "format = 'csv'" in sql
+        assert "header_row = true" in sql
+        assert "fieldterminator" in sql
+        assert "order_id int" in sql
+        assert "as [orders_tsv]" in sql
+
+
+class TestOpenrowsetJsonl:
+    """JSONL file with nested column path mapping."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "jsonl_model.sql": jsonl_model_sql,
+            "sources.yml": sources_jsonl_yml,
+        }
+
+    def test__jsonl_with_column_paths(self, project):
+        results = run_dbt(["compile", "-s", "jsonl_model"])
+        assert len(results) == 1
+
+        sql = _normalize(read_file("target", "compiled", "test", "models", "jsonl_model.sql"))
+
+        assert "format = 'jsonl'" in sql
+        # Simple columns
+        assert "event_id varchar(50)" in sql
+        assert "event_type varchar(50)" in sql
+        # Columns with JSON path mapping
+        assert "user_id int '$.user.id'" in sql
+        assert "user_name varchar(100)'$.user.name'" in sql
+        assert "page varchar(200)'$.properties.page'" in sql
+        assert "as [events]" in sql
+
+
+class TestOpenrowsetParquetNoSchema:
+    """Parquet file without column schema — engine auto-detects columns."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "parquet_no_schema_model.sql": parquet_no_schema_model_sql,
+            "sources.yml": sources_parquet_no_schema_yml,
+        }
+
+    def test__parquet_no_with_clause(self, project):
+        results = run_dbt(["compile", "-s", "parquet_no_schema_model"])
+        assert len(results) == 1
+
+        sql = _normalize(
+            read_file("target", "compiled", "test", "models", "parquet_no_schema_model.sql")
+        )
+
+        assert "openrowset(" in sql
+        assert "format = 'parquet'" in sql
+        assert "with(" not in sql
+        assert "as [customers_auto]" in sql
+
+
+class TestOpenrowsetExplicitFormat:
+    """Explicit format override — uses format: CSV even though extension is .csv."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "explicit_format_model.sql": explicit_format_model_sql,
+            "sources.yml": sources_explicit_format_yml,
+        }
+
+    def test__explicit_format(self, project):
+        results = run_dbt(["compile", "-s", "explicit_format_model"])
+        assert len(results) == 1
+
+        sql = _normalize(
+            read_file("target", "compiled", "test", "models", "explicit_format_model.sql")
+        )
+
+        assert "format = 'csv'" in sql
+        assert "header_row = true" in sql
+        assert "order_id int" in sql
+        assert "as [orders_explicit]" in sql
+
+
+class TestOpenrowsetFullPathOverride:
+    """Full path at table level bypasses source base path."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "full_path_model.sql": full_path_model_sql,
+            "sources.yml": sources_full_path_override_yml,
+        }
+
+    def test__full_path_override(self, project):
+        results = run_dbt(["compile", "-s", "full_path_model"])
+        assert len(results) == 1
+
+        sql = _normalize(read_file("target", "compiled", "test", "models", "full_path_model.sql"))
+
+        assert "bulk '{}/customers.parquet'".format(SAMPLE_DATA_PATH.lower()) in sql
+        assert "format = 'parquet'" in sql
+        assert "customer_id int" in sql
+        assert "first_name varchar(100)" in sql
+        assert "as [customers_direct]" in sql

--- a/tests/functional/adapter/test_quoting.py
+++ b/tests/functional/adapter/test_quoting.py
@@ -1,0 +1,239 @@
+"""
+Functional tests for T-SQL bracket quoting [identifier].
+
+Verifies that the adapter uses [] brackets (not "") across:
+  - table creation / selection
+  - seeds (column lists)
+  - incremental models (merge, delete+insert)
+  - snapshots (column additions)
+  - schema operations (USE, CREATE SCHEMA)
+  - identifiers with special characters (hyphens, spaces)
+"""
+
+import pytest
+from dbt.tests.util import get_manifest, run_dbt
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+_MODEL_TABLE = """
+{{ config(materialized='table') }}
+select 1 as id, 'alice' as user_name
+"""
+
+_MODEL_VIEW = """
+{{ config(materialized='view') }}
+select id, user_name from {{ ref('quoting_table') }}
+"""
+
+_MODEL_INCREMENTAL_DELETE_INSERT = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='delete+insert',
+    unique_key='id',
+) }}
+select 1 as id, 'alice' as user_name
+{% if is_incremental() %}
+union all
+select 2 as id, 'bob' as user_name
+{% endif %}
+"""
+
+_MODEL_SPECIAL_CHARS = """
+{{ config(materialized='table') }}
+select 1 as [col with spaces], 2 as [col-with-hyphens]
+"""
+
+# ---------------------------------------------------------------------------
+# Seeds
+# ---------------------------------------------------------------------------
+
+_SEED_CSV = """id,user_name,score
+1,alice,100
+2,bob,200
+3,charlie,300
+"""
+
+# ---------------------------------------------------------------------------
+# Snapshots
+# ---------------------------------------------------------------------------
+
+_SNAPSHOT = """
+{% snapshot quoting_snap %}
+{{ config(
+    target_schema=schema,
+    strategy='check',
+    unique_key='id',
+    check_cols=['user_name'],
+) }}
+select * from {{ ref('quoting_table') }}
+{% endsnapshot %}
+"""
+
+
+# ===================================================================
+# Test: basic table + view creation uses bracket quoting
+# ===================================================================
+class TestBracketQuotingTableAndView:
+    """Table and view creation should succeed with [schema].[table] quoting."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "quoting_table.sql": _MODEL_TABLE,
+            "quoting_view.sql": _MODEL_VIEW,
+        }
+
+    def test_run_and_query(self, project):
+        res = run_dbt(["run"])
+        assert len(res) == 2
+
+        # Verify data round-trips correctly
+        result = project.run_sql(
+            "select id, user_name from {schema}.quoting_table",
+            fetch="one",
+        )
+        assert result[0] == 1
+        assert result[1] == "alice"
+
+        result = project.run_sql(
+            "select id, user_name from {schema}.quoting_view",
+            fetch="one",
+        )
+        assert result[0] == 1
+        assert result[1] == "alice"
+
+
+# ===================================================================
+# Test: seeds produce bracket-quoted column lists
+# ===================================================================
+class TestBracketQuotingSeeds:
+    """Seed inserts should use [col] bracket quoting in INSERT column lists."""
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"quoting_seed.csv": _SEED_CSV}
+
+    def test_seed_and_query(self, project):
+        res = run_dbt(["seed"])
+        assert len(res) == 1
+
+        rows = project.run_sql(
+            "select count(*) from {schema}.quoting_seed",
+            fetch="one",
+        )
+        assert rows[0] == 3
+
+
+# ===================================================================
+# Test: incremental delete+insert with bracket quoting
+# ===================================================================
+class TestBracketQuotingIncrementalDeleteInsert:
+    """Incremental delete+insert should work with bracket-quoted identifiers."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "quoting_incr.sql": _MODEL_INCREMENTAL_DELETE_INSERT,
+        }
+
+    def test_incremental_runs(self, project):
+        # First run (full refresh)
+        res = run_dbt(["run"])
+        assert len(res) == 1
+
+        rows = project.run_sql(
+            "select count(*) from {schema}.quoting_incr",
+            fetch="one",
+        )
+        assert rows[0] == 1
+
+        # Second run (incremental)
+        res = run_dbt(["run"])
+        assert len(res) == 1
+
+        rows = project.run_sql(
+            "select count(*) from {schema}.quoting_incr",
+            fetch="one",
+        )
+        assert rows[0] == 2
+
+
+# ===================================================================
+# Test: snapshot uses bracket-quoted columns
+# ===================================================================
+class TestBracketQuotingSnapshot:
+    """Snapshot should work with bracket-quoted column references."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"quoting_table.sql": _MODEL_TABLE}
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"quoting_snap.sql": _SNAPSHOT}
+
+    def test_snapshot_runs(self, project):
+        # Create the source table first
+        run_dbt(["run"])
+
+        # First snapshot
+        res = run_dbt(["snapshot"])
+        assert len(res) == 1
+
+        rows = project.run_sql(
+            "select count(*) from {schema}.quoting_snap",
+            fetch="one",
+        )
+        assert rows[0] == 1
+
+        # Second snapshot (no changes)
+        res = run_dbt(["snapshot"])
+        assert len(res) == 1
+
+
+# ===================================================================
+# Test: special character identifiers with brackets
+# ===================================================================
+class TestBracketQuotingSpecialChars:
+    """Columns with spaces/hyphens should work via bracket quoting."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"special_chars.sql": _MODEL_SPECIAL_CHARS}
+
+    def test_special_char_columns(self, project):
+        res = run_dbt(["run"])
+        assert len(res) == 1
+
+        result = project.run_sql(
+            "select [col with spaces], [col-with-hyphens] from {schema}.special_chars",
+            fetch="one",
+        )
+        assert result[0] == 1
+        assert result[1] == 2
+
+
+# ===================================================================
+# Test: relation rendering produces bracket quoting (not double-quotes)
+# ===================================================================
+class TestRelationRenderingBrackets:
+    """Compiled SQL should contain [] brackets, not double-quote identifiers."""
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"quoting_table.sql": _MODEL_TABLE}
+
+    def test_compiled_sql_uses_brackets(self, project):
+        run_dbt(["compile"])
+        manifest = get_manifest(project.project_root)
+
+        for node_id, node in manifest.nodes.items():
+            if node.resource_type == "model" and hasattr(node, "relation_name"):
+                relation_name = node.relation_name
+                if relation_name:
+                    # Should not contain double-quote quoting
+                    assert (
+                        '""' not in relation_name
+                    ), f"Found double-quote quoting in {node_id}: {relation_name}"

--- a/tests/unit/adapters/fabric/test_execute_rows_affected.py
+++ b/tests/unit/adapters/fabric/test_execute_rows_affected.py
@@ -1,0 +1,130 @@
+from unittest import mock
+
+import pytest
+
+from dbt.adapters.fabric.fabric_connection_manager import FabricConnectionManager
+
+
+class MockCursor:
+    """Mock pyodbc cursor that simulates multiple result sets."""
+
+    def __init__(self, rowcounts, descriptions=None):
+        """
+        Parameters
+        ----------
+        rowcounts : list[int]
+            Row counts for each result set. The last value is what cursor.rowcount
+            should be after stepping through all result sets.
+        descriptions : list[tuple|None]
+            Description per result set. None means no result set (DDL).
+        """
+        self._rowcounts = list(rowcounts)
+        self._descriptions = descriptions or [None] * len(rowcounts)
+        self._index = 0
+        self.rowcount = rowcounts[0] if rowcounts else -1
+        self.description = self._descriptions[0] if self._descriptions else None
+
+    def nextset(self):
+        self._index += 1
+        if self._index < len(self._rowcounts):
+            self.rowcount = self._rowcounts[self._index]
+            self.description = self._descriptions[self._index]
+            return True
+        return False
+
+
+class MockConnection:
+    def __init__(self):
+        self.name = "test_connection"
+        self.transaction_open = True
+        self.credentials = mock.MagicMock()
+        self.credentials.retries = 1
+        self.handle = mock.MagicMock()
+
+
+@pytest.fixture
+def connection_manager():
+    cm = FabricConnectionManager.__new__(FabricConnectionManager)
+    return cm
+
+
+class TestExecuteRowsAffected:
+    """
+    Tests that execute() captures cursor.rowcount from the LAST result set,
+    not the first. This is critical for table materializations where
+    CREATE VIEW (rowcount=-1) runs before INSERT/CTAS (rowcount=N).
+    """
+
+    def test_rows_affected_from_last_result_set(self, connection_manager):
+        """
+        Simulates table materialization: CREATE VIEW (-1) then CTAS (42 rows).
+        rows_affected should be 42, not -1.
+        """
+        cursor = MockCursor(rowcounts=[-1, 42])
+
+        with mock.patch.object(connection_manager, "_add_query_comment", return_value="sql"):
+            with mock.patch.object(
+                connection_manager, "add_query", return_value=(MockConnection(), cursor)
+            ):
+                response, table = connection_manager.execute("sql", fetch=False)
+
+        assert response.rows_affected == 42
+
+    def test_rows_affected_single_statement(self, connection_manager):
+        """
+        Single statement returning 10 rows. rows_affected should be 10.
+        """
+        cursor = MockCursor(rowcounts=[10])
+
+        with mock.patch.object(connection_manager, "_add_query_comment", return_value="sql"):
+            with mock.patch.object(
+                connection_manager, "add_query", return_value=(MockConnection(), cursor)
+            ):
+                response, table = connection_manager.execute("sql", fetch=False)
+
+        assert response.rows_affected == 10
+
+    def test_rows_affected_ddl_only(self, connection_manager):
+        """
+        DDL-only statement (CREATE VIEW). rowcount is -1 throughout.
+        """
+        cursor = MockCursor(rowcounts=[-1])
+
+        with mock.patch.object(connection_manager, "_add_query_comment", return_value="sql"):
+            with mock.patch.object(
+                connection_manager, "add_query", return_value=(MockConnection(), cursor)
+            ):
+                response, table = connection_manager.execute("sql", fetch=False)
+
+        assert response.rows_affected == -1
+
+    def test_rows_affected_contract_path(self, connection_manager):
+        """
+        Simulates contract-enforced table materialization:
+        CREATE VIEW (-1) -> CREATE TABLE (-1) -> INSERT INTO (100 rows).
+        rows_affected should be 100.
+        """
+        cursor = MockCursor(rowcounts=[-1, -1, 100])
+
+        with mock.patch.object(connection_manager, "_add_query_comment", return_value="sql"):
+            with mock.patch.object(
+                connection_manager, "add_query", return_value=(MockConnection(), cursor)
+            ):
+                response, table = connection_manager.execute("sql", fetch=False)
+
+        assert response.rows_affected == 100
+
+    def test_rows_affected_incremental_delete_insert(self, connection_manager):
+        """
+        Simulates incremental delete+insert: DELETE (5 rows) then INSERT (10 rows).
+        rows_affected should be 10 (from the last INSERT).
+        """
+        cursor = MockCursor(rowcounts=[5, 10])
+
+        with mock.patch.object(connection_manager, "_add_query_comment", return_value="sql"):
+            with mock.patch.object(
+                connection_manager, "add_query", return_value=(MockConnection(), cursor)
+            ):
+                response, table = connection_manager.execute("sql", fetch=False)
+
+        assert response.rows_affected == 10


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the Fabric adapter for dbt, focusing on improved identifier quoting, new features for file-based sources, support for table clustering, and bug fixes. The most important changes are grouped below:

**1. Identifier Quoting Standardization**
- All SQL identifiers (columns, tables, etc.) are now consistently quoted using square brackets (`[identifier]`), aligning with T-SQL/Fabric conventions and preventing issues with reserved words or special characters. This affects macros, column definitions, and DDL statements throughout the adapter and macros. [[1]](diffhunk://#diff-529f3242d3cb0dbb13da6e1544cc0579af3346c5dfa161a037fa061b928aeb30R31-R35) [[2]](diffhunk://#diff-defed674f03fd35c0553363dbc23b358229325d8b21513f1232d797c3c33c9f8R8-R11) [[3]](diffhunk://#diff-a3667153c138d10f896f6515b0a174037156f11342e5d523975f333089c7d131R19-R21) [[4]](diffhunk://#diff-9de9fca3be8654da9aafe6726efd0bb9fba0a4b752d4a690e7d29d993f89ed1aL93-R93) [[5]](diffhunk://#diff-9de9fca3be8654da9aafe6726efd0bb9fba0a4b752d4a690e7d29d993f89ed1aL132-R137) [[6]](diffhunk://#diff-8634b5b5ed6be1f3acfbe46a0958246e68471b5ab88d32254ce4b1de4c99e3f2L24-R24) [[7]](diffhunk://#diff-8c397e67e581d9ff27fbf99ee5962858d2c56fc5bd6da72312dcf555d8ed1e55L9-R9)

**2. New Features**
- Added a new macro `openrowset_source` to support reading external files (Parquet, CSV, JSONL) via `OPENROWSET` in Fabric Data Warehouse. This macro includes flexible configuration and format detection, allowing users to easily define file-based sources in their dbt projects.
- Added support for the `cluster_by` config, enabling users to define clustering columns for tables at creation time, with validation and enforcement of Fabric's clustering constraints. [[1]](diffhunk://#diff-66bbd579ca5ccdee9fe828a9fc83f1718e31021ac903e2b47356fd1a68ac5146L2-R10) [[2]](diffhunk://#diff-92c703ae63c9de7b1718e664dcae7f993f5b55a5691246ab0f368df9c9420c12R7-R15) [[3]](diffhunk://#diff-92c703ae63c9de7b1718e664dcae7f993f5b55a5691246ab0f368df9c9420c12L24-R78)

**3. Bug Fixes and Behavioral Improvements**
- Fixed a bug in the connection manager so that the reported `rows_affected` count is accurate for table materializations, by ensuring the response is fetched after all result sets are processed. [[1]](diffhunk://#diff-c1b0256b44c042e86c431c5151b6c0812c05e8c047c1d4f9b12b0b9538cbdb55L739-L747) [[2]](diffhunk://#diff-c1b0256b44c042e86c431c5151b6c0812c05e8c047c1d4f9b12b0b9538cbdb55R758-R762)

**4. Configuration and Linting**
- Updated the `.pre-commit-config.yaml` to extend flake8 ignores with `E203`, improving compatibility with black formatting.

**5. Version Bump**
- Bumped the adapter version to `1.9.9`.