### PR TITLE
push schema filters into source CTEs to reduce row scans

### DIFF
--- a/dbt/include/fabric/macros/adapters/metadata.sql
+++ b/dbt/include/fabric/macros/adapters/metadata.sql
@@ -50,6 +50,7 @@
         SCHEMA_NAME(t.schema_id) as [schema],
         'table' as table_type
       from sys.tables as t {{ information_schema_hints() }}
+      where SCHEMA_NAME(t.schema_id) like '{{ schema_relation.schema }}'
       union all
       select
         DB_NAME() as [database],
@@ -57,9 +58,9 @@
         SCHEMA_NAME(v.schema_id) as [schema],
         'view' as table_type
       from sys.views as v {{ information_schema_hints() }}
+      where SCHEMA_NAME(v.schema_id) like '{{ schema_relation.schema }}'
     )
     select * from base
-    where [schema] like '{{ schema_relation.schema }}'
     {{ apply_label() }}
   {% endcall %}
   {{ return(load_result('list_relations_without_caching').table) }}
@@ -75,6 +76,8 @@
         SCHEMA_NAME(t.schema_id) as [schema],
         'table' as table_type
       from sys.tables as t {{ information_schema_hints() }}
+      where SCHEMA_NAME(t.schema_id) like '{{ schema_relation.schema }}'
+        and t.name like '{{ schema_relation.identifier }}'
       union all
       select
         DB_NAME() as [database],
@@ -82,10 +85,10 @@
         SCHEMA_NAME(v.schema_id) as [schema],
         'view' as table_type
       from sys.views as v {{ information_schema_hints() }}
+      where SCHEMA_NAME(v.schema_id) like '{{ schema_relation.schema }}'
+        and v.name like '{{ schema_relation.identifier }}'
     )
     select * from base
-    where [schema] like '{{ schema_relation.schema }}'
-    and [name] like '{{ schema_relation.identifier }}'
     {{ apply_label() }}
   {% endcall %}
   {{ return(load_result('get_relation_without_caching').table) }}


### PR DESCRIPTION
Move WHERE clauses into the individual UNION branches in
fabric__list_relations_without_caching and fabric__get_relation_without_caching
so that filtering happens directly on sys.tables and sys.views rather than
after the union is materialized.

We observed a query getting blocked, and our current working theory is that
concurrent DDL in the same workspace held locks on parts of sys.tables, and
our full scan ran into those locked rows. Filtering at the source likely
narrows the scan to the requested schema and may reduce exposure to such
contention.