### PR TITLE
fix: support case-sensitive Fabric Warehouse collations

### DIFF
--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -1,5 +1,5 @@
 import time
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import agate
 import dbt_common.exceptions
@@ -20,6 +20,7 @@ from dbt_common.contracts.constraints import (
     ModelLevelConstraint,
 )
 from dbt_common.events.functions import fire_event
+from dbt_common.utils import filter_null_values
 
 from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs
@@ -278,6 +279,15 @@ class FabricAdapter(SQLAdapter):
             return f"{constraint_prefix}{constraint.expression}"
         else:
             return None
+
+    def _make_match_kwargs(self, database: str, schema: str, identifier: str) -> Dict[str, str]:
+        return filter_null_values(
+            {
+                "database": database,
+                "identifier": identifier,
+                "schema": schema,
+            }
+        )
 
 
 COLUMNS_EQUAL_SQL = """

--- a/tests/functional/adapter/test_caching.py
+++ b/tests/functional/adapter/test_caching.py
@@ -1,4 +1,3 @@
-import pytest
 from dbt.tests.adapter.caching.test_caching import (
     BaseCachingLowercaseModel,
     BaseCachingSelectedSchemaOnly,
@@ -11,7 +10,6 @@ class TestCachingLowerCaseModel(BaseCachingLowercaseModel):
     pass
 
 
-@pytest.mark.skip(reason="Fabric DW does not support Case Insensivity.")
 class TestCachingUppercaseModel(BaseCachingUppercaseModel):
     pass
 


### PR DESCRIPTION
## Summary

Fixes #373.

`FabricAdapter` does not override `_make_match_kwargs`, so dbt-adapters' default runs unchanged and lowercases identifiers whenever `quoting.case_sensitive` is `False` (the dbt-core default). On a Fabric Warehouse provisioned with a case-sensitive collation (e.g. `SQL_Latin1_General_CP1_CS_AS`), dbt then asks Fabric for a relation by its lowercased name and Fabric correctly answers "no such object" — making the adapter unusable on that warehouse.

## How

Add a one-method override on `FabricAdapter` that uses `filter_null_values` to drop `None`s but preserves the original casing of `database`, `schema`, and `identifier`:

```python
def _make_match_kwargs(self, database: str, schema: str, identifier: str) -> Dict[str, str]:
    return filter_null_values(
        {
            "database": database,
            "identifier": identifier,
            "schema": schema,
        }
    )
```

Behaviour on case-insensitive collations is unchanged: Fabric's identifier comparison ignores case on those collations regardless of what we pass in.

## Test plan

- Unskip `TestCachingUppercaseModel` (was marked `pytest.mark.skip(reason="Fabric DW does not support Case Insensivity.")`). It exercises the relation-cache hit path with mixed-case identifiers; with the override in place it now passes against case-sensitive collations and continues to pass against case-insensitive ones.
- I'm a non-Microsoft contributor and cannot run the CI against the Microsoft Fabric tenant. Happy to add a local test-run screenshot if a maintainer wants to engage with the change.

Closes #373

