### PR TITLE
Fix `apply_grants` to surface Entra-principal grants

### DIFF
--- a/dbt/include/fabric/macros/adapters/apply_grants.sql
+++ b/dbt/include/fabric/macros/adapters/apply_grants.sql
@@ -1,11 +1,13 @@
 {% macro fabric__get_show_grant_sql(relation) %}
-    select
-        GRANTEE as grantee,
-        PRIVILEGE_TYPE as privilege_type
-    from INFORMATION_SCHEMA.TABLE_PRIVILEGES {{ information_schema_hints() }}
-    where TABLE_CATALOG = '{{ relation.database }}'
-      and TABLE_SCHEMA = '{{ relation.schema }}'
-      and TABLE_NAME = '{{ relation.identifier }}'
+    select distinct
+        pr.name as grantee,
+        pe.permission_name as privilege_type
+    from sys.database_principals as pr
+    inner join sys.database_permissions as pe
+      on pe.grantee_principal_id = pr.principal_id
+    where pe.major_id = object_id('[{{ relation.database }}].[{{ relation.schema }}].[{{ relation.identifier }}]')
+      and pe.state = 'G'
+      and pe.class_desc = 'OBJECT_OR_COLUMN'
 {% endmacro %}
 
 


### PR DESCRIPTION
Closes #374.

## Summary

`fabric__get_show_grant_sql` queries `INFORMATION_SCHEMA.TABLE_PRIVILEGES`, which on Fabric Warehouse only surfaces SQL-principal grants. Entra-principal grants (workspace users, groups, service principals, managed identities) are invisible to that view, even though they are in effect and listed in `sys.database_permissions`.

Because `apply_grants` diffs the result of `get_show_grant_sql` against the configured grants, every Entra principal in `grants:` shows up as missing on every run, so dbt re-issues the same `GRANT` indefinitely. Run logs and warehouse query history fill with redundant DDL, and the audit trail can't be used to spot real grant changes.

This PR rewrites `fabric__get_show_grant_sql` to join `sys.database_principals` against `sys.database_permissions`, which returns both SQL and Entra principals with their granted permissions.

## What changed

`dbt/include/fabric/macros/adapters/apply_grants.sql`:

```sql
{% macro fabric__get_show_grant_sql(relation) %}
    select distinct
        pr.name as grantee,
        pe.permission_name as privilege_type
    from sys.database_principals as pr
    inner join sys.database_permissions as pe
      on pe.grantee_principal_id = pr.principal_id
    where pe.major_id = object_id('[{{ relation.database }}].[{{ relation.schema }}].[{{ relation.identifier }}]')
      and pe.state = 'G'
      and pe.class_desc = 'OBJECT_OR_COLUMN'
{% endmacro %}
```

Shape (`grantee`, `privilege_type`) is preserved, so the rest of `apply_grants` is untouched. The `state = 'G'` filter keeps grant rows only (excluding `GRANT WITH GRANT OPTION` / deny rows), and `class_desc = 'OBJECT_OR_COLUMN'` scopes the result to table/view-level permissions, matching the previous query's intent.

## Testing notes

The maintainers may want to add a Microsoft-internal integration-test run against a Fabric Warehouse with both SQL and Entra grants on the same object before merging. I'm happy to:

- leave this as-is if the existing CI is sufficient, or
- extend `tests/functional/adapter/test_grants.py` if a specific test pattern is preferred.

The same fix has been running in [`sdebruyn/dbt-fabric`](https://github.com/sdebruyn/dbt-fabric) since [commit `42063121`](https://github.com/sdebruyn/dbt-fabric/commit/42063121) without regressions on warehouses that mix SQL and Entra principals.

