### PR TITLE
Drop unnecessary EXEC() wrapper from fabric__create_table_as

### DIFF
--- a/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -26,11 +26,10 @@
         {% endif %}
 
     {%- else %}
-        {%- set query_label_option = query_label.replace("'", "''") -%}
         {% if adapter.behavior.empty.no_warn %}
-            EXEC('CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} WHERE 0=1 {{ query_label_option }}');
+            CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} WHERE 0=1 {{ query_label }}
         {% else %}
-            EXEC('CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} {{ query_label_option }}');
+            CREATE TABLE {{relation}} {{ cluster_by_clause }} AS SELECT * FROM {{tmp_vw_relation}} {{ query_label }}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
# Why this change is needed

Filed as #377.

`fabric__create_table_as` wraps the `CREATE TABLE AS SELECT` in `EXEC('...')` and manually escapes single quotes in the query label via `.replace("'", "''")`. Fabric Warehouse supports CTAS as a first-class statement, so the wrapper is unnecessary, and the manual escape is fragile — it double-escapes pre-escaped apostrophes if a user-configured `query_tag` ever contains `''`. See #377 for details.

# How

Drop the `EXEC()` wrapper in the non-contract branch of `fabric__create_table_as` and emit a plain CTAS. The `query_label_option` intermediate (which only existed to call `.replace("'", "''")` on the label) is removed; the macro now uses `query_label` directly. The contract-enforced branch a few lines above already emits its `INSERT INTO ... SELECT` without an `EXEC()` wrapper, so this only brings the non-contract branch into line.

# Test

I'm a non-Microsoft contributor and cannot run the CI against the Microsoft Fabric tenant. Happy to add a local test-run screenshot if a maintainer wants to engage with the change.

Closes #377

