### PR TITLE
Surface cursor messages and statement id from get_response

### DIFF
--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -1,12 +1,13 @@
 import atexit
 import datetime as dt
+import re
 import struct
 import sys
 import threading
 import time
 from contextlib import contextmanager
 from itertools import chain, repeat
-from typing import Any, Callable, Dict, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type, Union
 
 import agate
 import dbt_common.exceptions
@@ -742,22 +743,30 @@ class FabricConnectionManager(SQLConnectionManager):
     def get_credentials(cls, credentials: FabricCredentials) -> FabricCredentials:
         return credentials
 
+    _STATEMENT_ID_RE = re.compile(
+        r"statement\s*id:\s*([0-9A-Fa-f-]{36})",
+        re.IGNORECASE,
+    )
+
     @classmethod
     def get_response(cls, cursor: Any) -> AdapterResponse:
-        # message = str(cursor.statusmessage)
-        message = "OK"
-        rows = cursor.rowcount
-        # status_message_parts = message.split() if message is not None else []
-        # status_messsage_strings = [
-        #    part
-        #    for part in status_message_parts
-        #    if not part.isdigit()
-        # ]
-        # code = ' '.join(status_messsage_strings)
+        messages = getattr(cursor, "messages", None) or []
+        text_parts: List[str] = []
+        statement_id: Optional[str] = None
+        for entry in messages:
+            text = (
+                entry[1]
+                if isinstance(entry, (list, tuple)) and len(entry) > 1
+                else str(entry)
+            )
+            text_parts.append(text)
+            match = cls._STATEMENT_ID_RE.search(text)
+            if match and statement_id is None:
+                statement_id = match.group(1)
         return AdapterResponse(
-            _message=message,
-            # code=code,
-            rows_affected=rows,
+            _message="\n".join(text_parts) if text_parts else "OK",
+            rows_affected=cursor.rowcount,
+            query_id=statement_id,
         )
 
     @classmethod


### PR DESCRIPTION
Fixes #389.

`FabricConnectionManager.get_response` discarded everything `cursor.messages` contained and returned a hardcoded `"OK"`. SQL warnings, `PRINT` output, deprecation notices, and the Fabric distributed statement ID never reached `AdapterResponse`, so dbt users had no visibility into cursor-side diagnostics and no way to correlate a dbt model with its server-side query in the Fabric portal or Capacity Metrics app.

## Changes

- Read `cursor.messages` and join the message texts into `AdapterResponse._message`. Falls back to `"OK"` only when the cursor produced no messages.
- Extract the distributed statement ID (the GUID that Fabric emits as `Statement ID: ...` in `cursor.messages`) and pass it through as `AdapterResponse.query_id`.
- The accidentally-commented `statusmessage` block is removed.

## Testing

Marking as draft so the maintainers can wire this through the project's test suite. Happy to extend the change with unit tests covering the message parsing and the GUID-extraction regex if that's the preferred follow-up.
