### PR TITLE
Override run_hooks so pre/post hooks do not emit commit;

### DIFF
--- a/dbt/include/fabric/macros/materializations/hooks.sql
+++ b/dbt/include/fabric/macros/materializations/hooks.sql
@@ -1,0 +1,10 @@
+{% macro run_hooks(hooks, inside_transaction=True) %}
+  {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction) %}
+    {% set rendered = render(hook.get('sql')) | trim %}
+    {% if (rendered | length) > 0 %}
+      {% call statement(auto_begin=inside_transaction) %}
+        {{ rendered }}
+      {% endcall %}
+    {% endif %}
+  {% endfor %}
+{% endmacro %}


### PR DESCRIPTION
Fixes #391.

## Summary

Adds `dbt/include/fabric/macros/materializations/hooks.sql` overriding `run_hooks` so the adapter no longer emits `commit;` between hook batches.

## Background

dbt-adapters' default `run_hooks` (at [`dbt/include/global_project/macros/materializations/hooks.sql`](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-adapters/src/dbt/include/global_project/macros/materializations/hooks.sql)) emits a `commit;` statement at the start of every batch of `inside_transaction=False` hooks, to close the implicit transaction wrapping a model.

Fabric Warehouse does not support `BEGIN`/`COMMIT TRAN`. The `commit;` statement is a T-SQL error, so every model with a `pre-hook` or `post-hook` fails at the hook boundary.

This is the same problem `dbt-athena` solves the same way — see [its `hooks.sql`](https://github.com/dbt-labs/dbt-adapters/blob/main/dbt-athena/src/dbt/include/athena/macros/materializations/hooks.sql).

## Change

The new `hooks.sql` defines a `run_hooks` macro that is identical to the dbt-adapters default with the `commit;` statement removed. The dbt-adapters macro is not dispatched, so the override is by macro name (adapter-namespaced macros override global ones).

## Test plan

- [ ] `dbt run` on a project with a `pre-hook` no longer errors at the hook boundary
- [ ] `dbt run` on a project with a `post-hook` no longer errors at the hook boundary
- [ ] `dbt build` still runs models inside the wrapping transaction (no regression on the `inside_transaction=True` path)
- [ ] Snapshot + on-run-start / on-run-end hooks still execute
