### PR TITLE
Dispatch microbatch to MERGE when unique_key is set

### DIFF
--- a/dbt/include/fabric/macros/materializations/models/incremental/merge.sql
+++ b/dbt/include/fabric/macros/materializations/models/incremental/merge.sql
@@ -138,6 +138,10 @@
 
 
 {% macro fabric__get_incremental_microbatch_sql(arg_dict) %}
+    {% if arg_dict["unique_key"] %}
+        {% do return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) %}
+    {% endif %}
+
     {%- set target = arg_dict["target_relation"] -%}
     {%- set source = arg_dict["temp_relation"] -%}
     {%- set dest_columns = arg_dict["dest_columns"] -%}


### PR DESCRIPTION
Fixes #393.

`fabric__get_incremental_microbatch_sql` performed a delete-then-insert sequence unconditionally, even when the model declared a `unique_key`. Fabric DW supports native `MERGE`, which is atomic and avoids the brief window where concurrent readers see deleted-but-not-yet-replaced rows.

## Change

When `arg_dict["unique_key"]` is set, dispatch to `get_incremental_merge_sql` so the operation runs as a single MERGE. The existing delete+insert path remains the fallback for microbatch models without a `unique_key`.

```jinja
{% macro fabric__get_incremental_microbatch_sql(arg_dict) %}
    {% if arg_dict["unique_key"] %}
        {% do return(adapter.dispatch('get_incremental_merge_sql', 'dbt')(arg_dict)) %}
    {% endif %}
    ...
```

## Testing

Happy to extend the change with a microbatch integration test that asserts MERGE is used when `unique_key` is set, if that's the preferred follow-up.
