### PR TITLE
Escape closing brackets in T-SQL identifier quoting

### DIFF
--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -35,7 +35,7 @@ class FabricAdapter(SQLAdapter):
 
     @classmethod
     def quote(cls, identifier):
-        return "[{}]".format(identifier)
+        return "[{}]".format(identifier.replace("]", "]]"))
 
     AdapterSpecificConfigs = FabricConfigs
     Relation = FabricRelation

--- a/dbt/adapters/fabric/fabric_column.py
+++ b/dbt/adapters/fabric/fabric_column.py
@@ -7,7 +7,7 @@ from dbt_common.exceptions import DbtRuntimeError
 class FabricColumn(Column):
     @property
     def quoted(self) -> str:
-        return "[{}]".format(self.column)
+        return "[{}]".format(self.column.replace("]", "]]"))
 
     TYPE_LABELS: ClassVar[Dict[str, str]] = {
         "STRING": "VARCHAR(8000)",

--- a/dbt/adapters/fabric/fabric_relation.py
+++ b/dbt/adapters/fabric/fabric_relation.py
@@ -17,7 +17,7 @@ class FabricRelation(BaseRelation):
     require_alias: bool = True
 
     def quoted(self, identifier):
-        return "[{}]".format(identifier)
+        return "[{}]".format(identifier.replace("]", "]]"))
 
     @classproperty
     def get_relation_type(cls) -> Type[FabricRelationType]:

--- a/dbt/include/fabric/macros/adapters/columns.sql
+++ b/dbt/include/fabric/macros/adapters/columns.sql
@@ -90,7 +90,7 @@
 
     {% set tempTable %}
         CREATE TABLE {{tempTableName}}
-        AS SELECT {{query_result_text}}, CAST([{{ column_name }}] AS {{new_column_type}}) AS [{{column_name}}] FROM {{ relation.schema }}.{{ relation.identifier }}
+        AS SELECT {{query_result_text}}, CAST([{{ column_name | replace(']', ']]') }}] AS {{new_column_type}}) AS [{{ column_name | replace(']', ']]') }}] FROM {{ relation.schema }}.{{ relation.identifier }}
         {{ apply_label() }}
     {% endset %}
 
@@ -129,12 +129,12 @@
   {% call statement('add_drop_columns') -%}
     {% if add_columns %}
         alter {{ relation.type }} {{ relation }}
-        add {% for column in add_columns %}[{{ column.name }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
+        add {% for column in add_columns %}[{{ column.name | replace(']', ']]') }}] {{ column.data_type }}{{ ', ' if not loop.last }}{% endfor %};
     {% endif %}
 
     {% if remove_columns %}
         alter {{ relation.type }} {{ relation }}
-        drop column {% for column in remove_columns %}[{{ column.name }}]{{ ',' if not loop.last }}{% endfor %};
+        drop column {% for column in remove_columns %}[{{ column.name | replace(']', ']]') }}]{{ ',' if not loop.last }}{% endfor %};
     {% endif %}
   {%- endcall -%}
 {% endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/create_table_as.sql
@@ -16,7 +16,7 @@
         {{ get_assert_columns_equivalent(sql)  }}
         {% set listColumns %}
             {% for column in model['columns'] %}
-                {{ "["~column~"]" }}{{ ", " if not loop.last }}
+                {{ "["~column|replace(']', ']]')~"]" }}{{ ", " if not loop.last }}
             {% endfor %}
         {%endset%}
 

--- a/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/snapshots/helpers.sql
@@ -6,7 +6,7 @@
 {% macro fabric__create_columns(relation, columns) %}
   {% for column in columns %}
     {% call statement() %}
-      alter table {{ relation.render() }} add [{{ column.name }}] {{ column.data_type }} NULL;
+      alter table {{ relation.render() }} add [{{ column.name | replace(']', ']]') }}] {{ column.data_type }} NULL;
     {% endcall %}
   {% endfor %}
 {% endmacro %}


### PR DESCRIPTION
Fixes #399.

`FabricAdapter.quote()`, `FabricColumn.quoted`, `FabricRelation.quoted`, and five Jinja macro sites all compose bracket-quoted T-SQL identifiers without escaping `]`. Any identifier containing `]` produces invalid T-SQL, and a crafted identifier of the form `foo];<sql>--` lets a name terminate the bracket and inject arbitrary T-SQL into whatever statement the macro is composing. The dbt-fabric attack surface is small (identifiers are usually static), but projects that derive names from external systems are exposed, and silent breakage on reserved-word columns containing `]` is a real bug regardless.

## Changes

Doubling `]` to `]]` inside the brackets is the standard T-SQL escape ([Delimited Identifiers](https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers#delimited-identifiers?WT.mc_id=MVP_310840)). Applied at every bracket-quoting site:

- `FabricAdapter.quote()` — `identifier.replace("]", "]]")` before the format.
- `FabricColumn.quoted` — same on `self.column`.
- `FabricRelation.quoted()` — same on `identifier`.
- `fabric__alter_column_type` (`columns.sql`) — both the `CAST` source and the alias.
- `fabric__alter_relation_add_remove_columns` (`columns.sql`) — `add` and `drop column` branches.
- `fabric__create_table_as` (`create_table_as.sql`) — the `listColumns` block used for `contract.enforced` models.
- `fabric__create_columns` (snapshot `helpers.sql`) — column addition during snapshot column expansion.

The Jinja escape uses the standard `| replace(']', ']]')` filter inside the existing `[ ... ]` wrapper.

## Out of scope

This PR only adds the missing escape. Two related quoting inconsistencies were noticed while writing the patch but kept out to keep the diff reviewable:

- `fabric__alter_column_type`'s metadata-query branch composes column names with double quotes (`'"' + ... + '"'`) while the rest of the file uses brackets.
- `fabric__get_use_database_sql` currently *strips* `[`/`]`/`"` from the database name rather than escaping them. That is safe against injection but silently rewrites identifiers that legitimately contain those characters.

Happy to follow up on either in separate PRs if useful.