### PR TITLE
Build incremental full refresh into a temp relation and swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * Bumped `dbt-adapters` requirement from `>=1.1.1,<2.0` to `>=1.10.0,<2.0`
 * Added Python 3.12 classifier
 
+## Improvements
+
+* **Incremental full refresh builds into a temp relation and swaps** — the `incremental` materialization's full-refresh path previously dropped the target table and ran `CREATE TABLE AS` in place, leaving the relation missing for the entire rebuild (concurrent readers error with "Invalid object name", which can last minutes on a large history rebuild). It now builds the replacement under a `__dbt_temp` name and swaps it into place with a metadata-only rename, keeping the previous data live until the swap. This matches the behavior of the `table` materialization. Resolves [#403](https://github.com/microsoft/dbt-fabric/issues/403).
+
 ### v1.9.10
 
 ## Features

--- a/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -24,18 +24,36 @@
 
   {% if existing_relation is none or full_refresh_mode or existing_relation.is_view %}
 
-    {% set tmp_vw_relation = target_relation.incorporate(path={"identifier": target_relation.identifier ~ '__dbt_tmp_vw'}, type='view')-%}
-    -- Dropping temp view relation if it exists
-    {{ adapter.drop_relation(tmp_vw_relation) }}
-    -- Dropping target relation if exists
-    {{ adapter.drop_relation(target_relation) }}
+    {#-- Build into a temp relation and swap, so the target stays live during the
+         rebuild instead of being dropped up front. Mirrors the `table` materialization. --#}
 
+    {%- set temp_relation = make_temp_relation(target_relation, '__dbt_temp') -%}
+    {% set tmp_vw_relation = temp_relation.incorporate(path={"identifier": temp_relation.identifier ~ '__dbt_tmp_vw'}, type='view')-%}
+
+    -- Clean up leftovers from any previously failed run
+    {{ adapter.drop_relation(tmp_vw_relation) }}
+    {{ adapter.drop_relation(temp_relation) }}
+
+    -- Build the replacement under the temp name; the live target stays in place
     {%- call statement('main') -%}
-      {{ get_create_table_as_sql(False, target_relation, sql)}}
+      {{ get_create_table_as_sql(False, temp_relation, sql)}}
     {%- endcall -%}
 
-    -- Dropping temp view relation
+    -- Dropping temp view relation created by create_table_as
     {{ adapter.drop_relation(tmp_vw_relation) }}
+
+    {% if existing_relation is not none and existing_relation.is_table %}
+      -- Swap with renames: existing -> backup, temp -> target, then drop backup
+      {%- set backup_relation = make_backup_relation(target_relation, 'table') -%}
+      {{ adapter.drop_relation(backup_relation) }}
+      {{ adapter.rename_relation(existing_relation, backup_relation) }}
+      {{ adapter.rename_relation(temp_relation, target_relation) }}
+      {{ adapter.drop_relation(backup_relation) }}
+    {% else %}
+      -- First build, or the existing relation was a view (already dropped above):
+      -- promote the temp relation to the target name.
+      {{ adapter.rename_relation(temp_relation, target_relation) }}
+    {% endif %}
 
     -- Add constraints including FK relation.
     {{ build_model_constraints(target_relation) }}

--- a/tests/functional/adapter/test_incremental_full_refresh.py
+++ b/tests/functional/adapter/test_incremental_full_refresh.py
@@ -1,0 +1,55 @@
+"""Full-refresh behavior for the `incremental` materialization.
+
+The full-refresh path builds the replacement under a `__dbt_temp` name and swaps
+it into place with a rename (instead of dropping the target and rebuilding it in
+situ). These tests assert that a full refresh still produces correct data and
+leaves no orphaned temp/backup relations behind.
+"""
+
+import pytest
+from dbt.tests.util import run_dbt
+
+_MODEL_INCREMENTAL = """
+{{ config(materialized='incremental', unique_key='id') }}
+
+select 1 as id, 'a' as letter
+union all select 2 as id, 'b' as letter
+{% if is_incremental() %}
+union all select 3 as id, 'c' as letter
+{% endif %}
+"""
+
+_COUNT_LEFTOVERS = """
+select count(*) as n
+from information_schema.tables
+where table_schema = '{schema}'
+  and (table_name like '%__dbt_temp%' or table_name like '%__dbt_backup%')
+"""
+
+
+class TestIncrementalFullRefreshSwapFabric:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"swap_model.sql": _MODEL_INCREMENTAL}
+
+    def test_full_refresh_swaps_and_cleans_up(self, project):
+        # Run 1 — first build (no existing relation): 2 rows.
+        run_dbt(["run", "--select", "swap_model"])
+        rows = project.run_sql("select count(*) from {schema}.swap_model", fetch="one")
+        assert rows[0] == 2
+
+        # Run 2 — incremental run: adds the third row via merge.
+        run_dbt(["run", "--select", "swap_model"])
+        rows = project.run_sql("select count(*) from {schema}.swap_model", fetch="one")
+        assert rows[0] == 3
+
+        # Run 3 — full refresh: rebuilds from scratch (is_incremental() false -> 2 rows).
+        run_dbt(["run", "--select", "swap_model", "--full-refresh"])
+        rows = project.run_sql("select count(*) from {schema}.swap_model", fetch="one")
+        assert rows[0] == 2
+
+        # The target survived the rebuild and no temp/backup relations were left behind.
+        leftovers = project.run_sql(
+            _COUNT_LEFTOVERS.format(schema=project.test_schema), fetch="one"
+        )
+        assert leftovers[0] == 0


### PR DESCRIPTION
# Build incremental full refresh into a temp relation and swap (avoid dropping the target up front)

Closes #403

## Problem

The `incremental` materialization's full-refresh path drops the target table and
then runs `CREATE TABLE AS` into the **same name**:

```jinja
-- Dropping target relation if exists
{{ adapter.drop_relation(target_relation) }}

{%- call statement('main') -%}
  {{ get_create_table_as_sql(False, target_relation, sql) }}
{%- endcall -%}
```

Because the drop happens before the (potentially long) CTAS, the relation is
**missing for the entire duration of the rebuild** — not empty, gone. Any
concurrent reader (BI/report, a downstream model, an ad-hoc query) fails with
`Invalid object name` until the rebuild finishes. On a large history rebuild
that window can be minutes.

This is inconsistent with the `table` materialization
(`models/table/table.sql`), which already builds into a temp relation and swaps
via rename, keeping the previous data live throughout.

## Change

Rework the full-refresh / first-build / view-to-table branch of
`fabric__` incremental to mirror `table.sql`:

1. Build the replacement under a `__dbt_temp` name (target stays live).
2. If a live target table exists: rename `existing -> __dbt_backup`,
   `__dbt_temp -> target`, then drop the backup.
3. First build (no existing relation) or existing-was-a-view (already dropped
   earlier in the materialization): just rename `__dbt_temp -> target`.
4. `build_model_constraints(target_relation)` runs after the swap, unchanged.

The incremental (non-full-refresh) branch is untouched.

## Why this is safe

- It reuses the exact primitives the `table` materialization already relies on
  (`make_temp_relation`, `make_backup_relation`, `rename_relation` via
  `sp_rename`, and the `__dbt_tmp_vw` helper view created by
  `fabric__create_table_as`) — all same-schema, table-typed relations.
- Contract enforcement is preserved: `create_table_as` builds the temp table
  with column constraints, and `build_model_constraints` adds FK constraints to
  the renamed target afterward — identical to the `table` path.
- Existing full-refresh correctness is already covered by the inherited
  `BaseIncrementalUniqueKey` / `BaseIncrementalPredicates` suites
  (`run_dbt([..., "--full-refresh"])`).

## Known limitation (unchanged from `table.sql`)

T-SQL has no atomic swap, so there is still a sub-second metadata gap between the
two `sp_rename` calls. This is strictly better than the previous behavior (gap
shrinks from "whole rebuild" to "two renames") and matches the `table`
materialization exactly. Peak storage briefly holds old + new (also same as
`table`).

## Tests

Added `tests/functional/adapter/test_incremental_full_refresh.py`: builds
incremental -> incremental -> `--full-refresh`, asserts correct row counts at
each step and that no `__dbt_temp` / `__dbt_backup` relations are orphaned after
the swap.
