### PR TITLE
Retry 08S01 connection resets during result-set fetch (SQLMoreResults) (#417)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### v1.10.1
+
+## Bug Fixes
+
+* **Retry `08S01` connection resets during result-set fetch (`SQLMoreResults`)** — `FabricConnectionManager.execute()` walked result sets (`cursor.nextset()`) outside any retry wrapper, and called `add_query()` without a `retryable_exceptions` tuple, so its retry loop compiled to `except ()` and never matched. A connection reset that surfaced mid-fetch therefore failed the run outright, even with `ConnectRetryCount` set — because `ConnectRetryCount` only retries the initial connect and restores *idle* pooled connections, not a connection actively streaming results, which Fabric Warehouse's gateway resets when it recycles a session. `execute()` now threads the same retryable-exception set used at connect time (`OperationalError`, `InternalError`, plus `InterfaceError` for AAD auth) into `add_query()`, and wraps the result-set walk so a reset re-establishes the connection and re-runs the whole statement from a fresh cursor, bounded by the `retries` credential. Gated behind a new opt-in `retry_result_set_errors` credential (default `False`), because re-running a statement can double-apply a `MERGE`/`INSERT` that partially committed before the reset was observed; existing behaviour is unchanged when it is off. Resolves [#417](https://github.com/microsoft/dbt-fabric/issues/417).
+
 ### v1.10.0
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -96,6 +96,29 @@ flags:
 
 Or pass `--no-populate-cache` on the CLI for a single run. This prevents dbt from listing every schema in the warehouse upfront, significantly reducing catalog read pressure during concurrent runs.
 
+## Retrying mid-fetch connection resets (`08S01`)
+
+Fabric Warehouse's gateway can recycle a session while a statement is still streaming results, surfacing as:
+
+```
+('08S01', '[08S01] [Microsoft][ODBC Driver 18 for SQL Server]TCP Provider: Error code 0x68 (104) (SQLMoreResults)')
+```
+
+`ConnectRetryCount` does **not** cover this — it only retries the initial connect and restores *idle* pooled connections, not one actively mid-fetch. Set `retry_result_set_errors: true` to make the adapter re-establish the connection and re-run the statement (up to `retries` times) when this happens:
+
+```yaml
+# profiles.yml
+my_fabric_project:
+  outputs:
+    dev:
+      type: fabric
+      # ... connection settings ...
+      retries: 3
+      retry_result_set_errors: true  # default false
+```
+
+It is **off by default** because the retry re-runs the whole statement, which can double-apply a `MERGE`/`INSERT` that had already partially committed before the reset surfaced. Enable it only when your target hits these resets and its statements are safe to re-execute (e.g. the CTAS/backup-relation patterns the adapter emits for `table`/`view` materializations). See [#417](https://github.com/microsoft/dbt-fabric/issues/417).
+
 ## Changelog
 
 See [the changelog](CHANGELOG.md)

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -31,7 +31,7 @@ from azure.core.credentials import AccessToken
 from azure.identity import AzureCliCredential, DefaultAzureCredential, EnvironmentCredential
 from dbt.adapters.contracts.connection import AdapterResponse, Connection, ConnectionState
 from dbt.adapters.events.logging import AdapterLogger
-from dbt.adapters.events.types import AdapterEventDebug, ConnectionUsed, SQLQuery, SQLQueryStatus
+from dbt.adapters.events.types import ConnectionUsed, SQLQuery, SQLQueryStatus
 from dbt.adapters.sql import SQLConnectionManager
 from dbt_common.clients.agate_helper import empty_table
 from dbt_common.events.contextvars import get_node_info
@@ -473,6 +473,22 @@ class FabricConnectionManager(SQLConnectionManager):
             raise dbt_common.exceptions.DbtRuntimeError(e)
 
     @classmethod
+    def _get_retryable_exceptions(
+        cls, credentials: FabricCredentials
+    ) -> Tuple[Type[Exception], ...]:
+        # https://github.com/mkleehammer/pyodbc/wiki/Exceptions
+        retryable_exceptions = [
+            pyodbc.InternalError,  # not used according to docs, but defined in PEP-249
+            pyodbc.OperationalError,
+        ]
+
+        if credentials.authentication.lower() in AZURE_AUTH_FUNCTIONS:
+            # Temporary login/token errors fall into this category when using AAD
+            retryable_exceptions.append(pyodbc.InterfaceError)
+
+        return tuple(retryable_exceptions)
+
+    @classmethod
     def open(cls, connection: Connection) -> Connection:
         if connection.state == ConnectionState.OPEN:
             logger.debug("Connection is already open, skipping open.")
@@ -557,14 +573,7 @@ class FabricConnectionManager(SQLConnectionManager):
 
         con_str_display = ";".join(con_str)
 
-        retryable_exceptions = [  # https://github.com/mkleehammer/pyodbc/wiki/Exceptions
-            pyodbc.InternalError,  # not used according to docs, but defined in PEP-249
-            pyodbc.OperationalError,
-        ]
-
-        if credentials.authentication.lower() in AZURE_AUTH_FUNCTIONS:
-            # Temporary login/token errors fall into this category when using AAD
-            retryable_exceptions.append(pyodbc.InterfaceError)
+        retryable_exceptions = cls._get_retryable_exceptions(credentials)
 
         def connect():
             logger.debug(f"Using connection string: {con_str_display}")
@@ -669,10 +678,9 @@ class FabricConnectionManager(SQLConnectionManager):
                 if attempt >= retry_limit:
                     raise e
 
-                fire_event(
-                    AdapterEventDebug(
-                        message=f"Got a retryable error {type(e)}. {retry_limit-attempt} retries left. Retrying in 1 second.\nError:\n{e}"
-                    )
+                logger.debug(
+                    f"Got a retryable error {type(e)}. {retry_limit-attempt} retries left. "
+                    f"Retrying in 1 second.\nError:\n{e}"
                 )
                 time.sleep(1)
 
@@ -765,22 +773,80 @@ class FabricConnectionManager(SQLConnectionManager):
         data_type = str(type_code)[str(type_code).index("'") + 1 : str(type_code).rindex("'")]  # type: ignore
         return datatypes[data_type]
 
+    def _reconnect(self, connection: Connection) -> Connection:
+        """
+        Force a fresh connection before re-running a statement.
+
+        An 08S01 reset surfaced while stepping through result sets leaves the
+        underlying pyodbc connection dead, so re-running the statement on the
+        same handle would just fail again. Close it (best-effort) and re-open.
+        """
+        try:
+            if connection.handle is not None:
+                connection.handle.close()
+        except Exception:
+            logger.debug("Failed to close handle before reconnect; continuing.")
+
+        connection.state = ConnectionState.CLOSED
+        connection.handle = None
+        return self.open(connection)
+
     def execute(
         self, sql: str, auto_begin: bool = True, fetch: bool = False, limit: Optional[int] = None
     ) -> Tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
-        _, cursor = self.add_query(sql, auto_begin)
-        if fetch:
-            # Get the result of the first non-empty result set (if any)
-            while cursor.description is None:
-                if not cursor.nextset():
-                    break
-            table = self.get_result_from_cursor(cursor, limit)
+
+        connection = self.get_thread_connection()
+        credentials = self.get_credentials(connection.credentials)
+
+        # Opt-in (see FabricCredentials.retry_result_set_errors and issue #417).
+        # When disabled, retryable_exceptions is empty and the walk below runs
+        # exactly once, preserving the previous behaviour.
+        if getattr(credentials, "retry_result_set_errors", False):
+            retryable_exceptions = self._get_retryable_exceptions(credentials)
+            retry_limit = credentials.retries if credentials.retries > 3 else 2
         else:
-            table = empty_table()
-        # Step through all result sets so we process all errors
-        while cursor.nextset():
-            pass
+            retryable_exceptions: Tuple[Type[Exception], ...] = ()
+            retry_limit = 0
+
+        attempt = 0
+        while True:
+            # add_query() already retries the initial cursor.execute() on these
+            # exceptions; passing the tuple restores that path (previously it
+            # defaulted to an empty tuple and never retried). See issue #417.
+            _, cursor = self.add_query(sql, auto_begin, retryable_exceptions=retryable_exceptions)
+            try:
+                if fetch:
+                    # Get the result of the first non-empty result set (if any)
+                    while cursor.description is None:
+                        if not cursor.nextset():
+                            break
+                    table = self.get_result_from_cursor(cursor, limit)
+                else:
+                    table = empty_table()
+                # Step through all result sets so we process all errors
+                while cursor.nextset():
+                    pass
+            except retryable_exceptions as e:
+                # A connection reset during the result-set walk (e.g. 08S01 /
+                # SQLMoreResults) has no retry coverage in add_query(), which
+                # only wraps the initial execute. Re-establish the connection
+                # and re-run the whole statement from a fresh cursor.
+                attempt += 1
+                if attempt > retry_limit:
+                    raise
+
+                logger.debug(
+                    f"Got a retryable error {type(e)} while stepping through result sets. "
+                    f"{retry_limit - attempt + 1} retries left. "
+                    f"Re-running statement in 1 second.\nError:\n{e}"
+                )
+                time.sleep(1)
+                connection = self._reconnect(connection)
+                continue
+
+            break
+
         # Get response after stepping through all result sets
         # so that cursor.rowcount reflects the last statement executed.
         # This fixes rows_affected being -1 for table materializations

--- a/dbt/adapters/fabric/fabric_credentials.py
+++ b/dbt/adapters/fabric/fabric_credentials.py
@@ -36,6 +36,14 @@ class FabricCredentials(Credentials):
     # Useful when routing connections through a proxy or when catalog-lock
     # contention makes it preferable to open a fresh connection each time.
     pooling: Optional[bool] = True
+    # Set to True to retry statements that hit a transient connection reset
+    # (08S01) while stepping through result sets (SQLMoreResults). Off by
+    # default because the retry re-runs the whole statement, which can
+    # double-apply a MERGE/INSERT that partially committed before the reset
+    # surfaced. Only enable for targets (e.g. Fabric Warehouse) whose gateway
+    # recycles sessions mid-fetch and whose statements are re-execution-safe.
+    # See https://github.com/microsoft/dbt-fabric/issues/417
+    retry_result_set_errors: Optional[bool] = False
 
     _ALIASES = {
         "user": "UID",
@@ -97,6 +105,7 @@ class FabricCredentials(Credentials):
             "trust_cert",
             "api_url",
             "pooling",
+            "retry_result_set_errors",
         )
 
     @property

--- a/tests/unit/adapters/fabric/test_execute_rows_affected.py
+++ b/tests/unit/adapters/fabric/test_execute_rows_affected.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 
 from dbt.adapters.fabric.fabric_connection_manager import FabricConnectionManager
+from dbt.adapters.fabric.fabric_credentials import FabricCredentials
 
 
 class MockCursor:
@@ -37,14 +38,23 @@ class MockConnection:
     def __init__(self):
         self.name = "test_connection"
         self.transaction_open = True
-        self.credentials = mock.MagicMock()
-        self.credentials.retries = 1
+        # Real credentials so execute() reads retry_result_set_errors (False by
+        # default) rather than a truthy MagicMock attribute.
+        self.credentials = FabricCredentials(
+            driver="ODBC Driver 18 for SQL Server",
+            host="fake.sql.fabric.net",
+            database="dbt",
+            schema="fabric",
+        )
         self.handle = mock.MagicMock()
 
 
 @pytest.fixture
 def connection_manager():
     cm = FabricConnectionManager.__new__(FabricConnectionManager)
+    # execute() now reads credentials via get_thread_connection(); the manager
+    # is built with __new__ (no lock), so stub it to a plain MockConnection.
+    cm.get_thread_connection = lambda: MockConnection()
     return cm
 
 

--- a/tests/unit/adapters/fabric/test_sql_server_connection_manager.py
+++ b/tests/unit/adapters/fabric/test_sql_server_connection_manager.py
@@ -2,10 +2,12 @@ import datetime as dt
 import json
 from unittest import mock
 
+import pyodbc
 import pytest
 from azure.identity import AzureCliCredential
 
 from dbt.adapters.fabric.fabric_connection_manager import (
+    FabricConnectionManager,
     bool_to_connection_string_arg,
     byte_array_to_datetime,
     get_pyodbc_attrs_before_credentials,
@@ -130,3 +132,176 @@ def test_byte_array_to_datetime(
     """
     assert byte_array_to_datetime(value) == expected_datetime
     assert str(byte_array_to_datetime(value)) == expected_str
+
+
+class TestGetRetryableExceptions:
+    """FabricConnectionManager._get_retryable_exceptions builds the tuple that
+    is threaded into both retry_connection() and execute()."""
+
+    def test_includes_operational_and_internal_error(self, credentials: FabricCredentials) -> None:
+        credentials.authentication = "ActiveDirectoryServicePrincipal"
+        retryable = FabricConnectionManager._get_retryable_exceptions(credentials)
+        assert pyodbc.OperationalError in retryable
+        assert pyodbc.InternalError in retryable
+        # InterfaceError is only added for token/AAD auth modes handled by
+        # AZURE_AUTH_FUNCTIONS (cli/auto/environment/...), not for the ODBC
+        # ActiveDirectory* driver auth modes.
+        assert pyodbc.InterfaceError not in retryable
+
+    def test_adds_interface_error_for_token_auth(self, credentials: FabricCredentials) -> None:
+        credentials.authentication = "CLI"
+        retryable = FabricConnectionManager._get_retryable_exceptions(credentials)
+        assert pyodbc.InterfaceError in retryable
+
+
+class _NextsetCursor:
+    """
+    Minimal cursor stand-in for execute()'s result-set walk.
+
+    nextset() raises `error` on its first `fail_times` invocations for THIS
+    cursor, then returns False (no further result sets). A fresh cursor is
+    handed out per execute() attempt, so "fail once then succeed" is modelled
+    with one failing cursor followed by a clean one.
+    """
+
+    def __init__(self, error=None, fail_times=0, rowcount=10):
+        self._error = error
+        self._fail_times = fail_times
+        self._calls = 0
+        self.rowcount = rowcount
+        self.description = None
+
+    def nextset(self):
+        self._calls += 1
+        if self._error is not None and self._calls <= self._fail_times:
+            raise self._error
+        return False
+
+
+class TestExecuteResultSetRetry:
+    """
+    execute() must retry a connection reset (08S01 / SQLMoreResults) that
+    surfaces while stepping through result sets, when the opt-in
+    retry_result_set_errors credential is set. See issue #417.
+    """
+
+    @pytest.fixture
+    def connection_manager(self):
+        return FabricConnectionManager.__new__(FabricConnectionManager)
+
+    def _run_execute(self, cm, credentials, cursors):
+        """
+        Drive execute() with add_query handing out the given cursors in order
+        and _reconnect stubbed out. Returns (response, table, add_query_mock,
+        reconnect_mock).
+        """
+        connection = mock.MagicMock()
+        connection.credentials = credentials
+
+        add_query = mock.MagicMock(side_effect=[(connection, cur) for cur in cursors])
+        reconnect = mock.MagicMock(return_value=connection)
+
+        with mock.patch.object(cm, "_add_query_comment", return_value="sql"), mock.patch.object(
+            cm, "get_thread_connection", return_value=connection
+        ), mock.patch.object(cm, "add_query", add_query), mock.patch.object(
+            cm, "_reconnect", reconnect
+        ), mock.patch(
+            "time.sleep"
+        ):
+            response, table = cm.execute("sql", fetch=False)
+
+        return response, table, add_query, reconnect
+
+    def test_retries_and_succeeds_on_reset_during_nextset(self, connection_manager, credentials):
+        """A retryable reset during the walk re-runs the statement on a fresh
+        connection and then succeeds."""
+        credentials.retry_result_set_errors = True
+        credentials.retries = 3  # effective retry limit = 2
+
+        reset = pyodbc.OperationalError("08S01", "TCP Provider: Error code 0x68 (SQLMoreResults)")
+        cursors = [
+            _NextsetCursor(error=reset, fail_times=1),  # attempt 1: reset
+            _NextsetCursor(rowcount=42),  # attempt 2: clean
+        ]
+
+        response, _, add_query, reconnect = self._run_execute(
+            connection_manager, credentials, cursors
+        )
+
+        assert response.rows_affected == 42
+        assert add_query.call_count == 2
+        assert reconnect.call_count == 1
+
+    def test_raises_after_exhausting_retry_limit(self, connection_manager, credentials):
+        """When every attempt resets, execute() gives up and re-raises."""
+        credentials.retry_result_set_errors = True
+        credentials.retries = 3  # effective retry limit = 2 -> 3 attempts total
+
+        reset = pyodbc.OperationalError("08S01", "SQLMoreResults")
+        cursors = [_NextsetCursor(error=reset, fail_times=1) for _ in range(3)]
+
+        with pytest.raises(pyodbc.OperationalError):
+            self._run_execute(connection_manager, credentials, cursors)
+
+    def test_non_retryable_exception_not_swallowed(self, connection_manager, credentials):
+        """A non-retryable error during the walk is not caught by the retry."""
+        credentials.retry_result_set_errors = True
+        credentials.retries = 3
+
+        cursors = [_NextsetCursor(error=ValueError("boom"), fail_times=1)]
+
+        with pytest.raises(ValueError):
+            self._run_execute(connection_manager, credentials, cursors)
+
+    def test_disabled_by_default_does_not_retry(self, connection_manager, credentials):
+        """With the flag off (default), a reset during the walk is not retried;
+        it propagates on the first occurrence, preserving prior behaviour."""
+        assert credentials.retry_result_set_errors is False
+
+        connection = mock.MagicMock()
+        connection.credentials = credentials
+        reset = pyodbc.OperationalError("08S01", "SQLMoreResults")
+        cursor = _NextsetCursor(error=reset, fail_times=1)
+        add_query = mock.MagicMock(return_value=(connection, cursor))
+        reconnect = mock.MagicMock(return_value=connection)
+
+        with mock.patch.object(
+            connection_manager, "_add_query_comment", return_value="sql"
+        ), mock.patch.object(
+            connection_manager, "get_thread_connection", return_value=connection
+        ), mock.patch.object(
+            connection_manager, "add_query", add_query
+        ), mock.patch.object(
+            connection_manager, "_reconnect", reconnect
+        ), mock.patch(
+            "time.sleep"
+        ):
+            with pytest.raises(pyodbc.OperationalError):
+                connection_manager.execute("sql", fetch=False)
+
+        assert add_query.call_count == 1
+        assert reconnect.call_count == 0
+
+        connection = mock.MagicMock()
+        connection.credentials = credentials
+        reset = pyodbc.OperationalError("08S01", "SQLMoreResults")
+        cursor = _NextsetCursor(error=reset, fail_times=1)
+        add_query = mock.MagicMock(return_value=(connection, cursor))
+        reconnect = mock.MagicMock(return_value=connection)
+
+        with mock.patch.object(
+            connection_manager, "_add_query_comment", return_value="sql"
+        ), mock.patch.object(
+            connection_manager, "get_thread_connection", return_value=connection
+        ), mock.patch.object(
+            connection_manager, "add_query", add_query
+        ), mock.patch.object(
+            connection_manager, "_reconnect", reconnect
+        ), mock.patch(
+            "time.sleep"
+        ):
+            with pytest.raises(pyodbc.OperationalError):
+                connection_manager.execute("sql", fetch=False)
+
+        assert add_query.call_count == 1
+        assert reconnect.call_count == 0


### PR DESCRIPTION
## Summary

Fixes #417.

A connection reset that occurs **mid-result-set-fetch** (`08S01` / `SQLMoreResults`, underlying WinSock `0x68`/`104` `ECONNRESET`) was never retried, even with `ConnectRetryCount` set — the run failed outright. Fabric Warehouse's gateway recycles sessions this way more aggressively than classic SQL Server, and `ConnectRetryCount` does not cover it (it only retries the initial connect and restores *idle* pooled connections, not a connection actively streaming results).

## Root cause (two independent gaps in `fabric_connection_manager.py`)

1. **`execute()` walked result sets outside any retry wrapper.** `add_query()` / `_execute_query_with_retry()` only wrap the initial `cursor.execute(sql)`. The two `cursor.nextset()` loops in `execute()` run *after* `add_query()` returns, so a reset there had zero retry coverage.
2. **The one wrapped call never actually retried.** `execute()` called `add_query(sql, auto_begin)` with no `retryable_exceptions`, so it fell back to the default `()` and `except retryable_exceptions` compiled to `except ()` — which matches nothing. The tuple built in `open()` was only ever used by `retry_connection()` for the initial login.

## Changes

- Factor the retryable-exception set (`pyodbc.OperationalError`, `pyodbc.InternalError`, + `pyodbc.InterfaceError` for AAD auth) out of `open()` into `_get_retryable_exceptions()` and reuse it.
- `execute()` now threads that tuple into `add_query()` (fixing gap 2) **and** wraps the result-set walk so a retryable reset re-establishes the connection (`_reconnect`) and re-runs the whole statement from a fresh cursor, bounded by the `retries` credential (fixing gap 1). A cursor's fetch state can't be resumed after a reset, so re-running the statement is the retry unit.
- Fixed the `add_query()` retry-debug event, which used `AdapterEventDebug(message=…)` — an unsupported field on current `dbt-adapters` (the event expects `base_msg`). This path was previously unreachable (empty retryable tuple) and becomes reachable once `execute()` enables retries; switched to `logger.debug(...)`.

## Design decision — the open question from #417

Re-running a statement is safe for read/CTAS-style operations but could **double-apply** a raw `MERGE`/`INSERT` that partially committed before the reset surfaced. Incremental strategies (`fabric__get_incremental_merge_sql`) emit exactly such mutating statements through the same `execute()` path, and `execute()` has no reliable signal for the statement/materialization type. So:

- **(a) unconditional** — rejected: unsafe for `merge`/incremental.
- **(b) gate by materialization type** — rejected: would require sniffing SQL text in the connection manager; fragile.
- **(c) opt-in flag** — **chosen.** New `retry_result_set_errors` credential (default `False`). Existing users see identical behaviour; those hitting Fabric's gateway resets opt in and accept the re-execution semantics.

Happy to switch to (b) or a different default if maintainers prefer.

## Testing

- New unit tests in `test_sql_server_connection_manager.py`: retry-then-succeed on a `nextset()` reset, exhausting the retry limit re-raises, non-retryable exceptions pass through, and disabled-by-default does not retry; plus `_get_retryable_exceptions` coverage.
- `test_execute_rows_affected.py` updated for `execute()` now reading credentials via `get_thread_connection()`.
- `dbt/adapters/fabric` unit tests pass locally (3 pre-existing `AzureCliCredential` failures are environmental — no `az` on PATH — and reproduce on unmodified `main`). `black`/`isort` clean.

## Docs

- `CHANGELOG.md` (`v1.10.1` → Bug Fixes) and a README section documenting the credential and its caveat.
