### PR TITLE
Enhance table refreshes, fix service principal auth, and alias rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+### v1.11.2rc1
+
+## Improvements
+
+* **Schema-aware full refreshes** — table models and incremental models running with
+  `--full-refresh` preserve the existing table object when its ordered schema, identity
+  properties, and `cluster_by` layout are unchanged. The adapter performs an atomic
+  `TRUNCATE` and full reload, retaining object-bound metadata and optimization history.
+  Named primary-key, unique, and foreign-key constraints are reconciled transactionally.
+  Schema, identity, physical-layout, or non-reconcilable custom-constraint changes use an
+  atomic CTAS/drop/rename replacement.
+
 ### v1.11.0
 
 ## Features
@@ -58,7 +70,7 @@
 * Improving table materialization to minimize downtime #189
 * Handling temp tables in incremental models #188
 * Add label support to filter queries #181
-* Addressed bug - incremental models cannot full refresh #179 
+* Addressed bug - incremental models cannot full refresh #179
 * Addressed bug - #197, dbt test incorrect syntax with macro helpers.sql
 
 ### v1.8.0rc2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@
 
 ## Bug Fixes
 
-* **`--empty` with explicitly aliased relations** — stop adding generated aliases to
-  limited `ref()` and `source()` relations, preventing invalid double aliases when model
-  SQL supplies its own alias. Resolves
-  [#437](https://github.com/microsoft/dbt-fabric/issues/437).
-
 * **Service principal authentication with `mssql-python`** — retain support for the
   `ServicePrincipal` profile alias and stop adding the unsupported `Authority Id`
   connection-string keyword. `ActiveDirectoryServicePrincipal` now uses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
   Schema, identity, physical-layout, or non-reconcilable custom-constraint changes use an
   atomic CTAS/drop/rename replacement.
 
+## Bug Fixes
+
+* **Service principal authentication with `mssql-python`** — retain support for the
+  `ServicePrincipal` profile alias and stop adding the unsupported `Authority Id`
+  connection-string keyword. `ActiveDirectoryServicePrincipal` now uses the
+  `Authentication`, `UID`, and `PWD` fields supported by `mssql-python`. Resolves
+  [#434](https://github.com/microsoft/dbt-fabric/issues/434).
+
 ### v1.11.0
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 
 ## Bug Fixes
 
+* **`--empty` with explicitly aliased relations** — stop adding generated aliases to
+  limited `ref()` and `source()` relations, preventing invalid double aliases when model
+  SQL supplies its own alias. Resolves
+  [#437](https://github.com/microsoft/dbt-fabric/issues/437).
+
 * **Service principal authentication with `mssql-python`** — retain support for the
   `ServicePrincipal` profile alias and stop adding the unsupported `Authority Id`
   connection-string keyword. `ActiveDirectoryServicePrincipal` now uses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ## Improvements
 
+* **Warehouse transaction support** — model, seed, snapshot, function, hook,
+  grant, constraint, statistics, and table-clone operations now participate in
+  dbt-managed `BEGIN`/`COMMIT`/`ROLLBACK` boundaries. Failed table reloads,
+  relation replacements, incremental writes, schema changes, seed resets, and
+  table or function creation restore the previous target instead of leaving
+  partial data or temporary relations. Clone and function grants,
+  documentation metadata, and transactional hooks commit with their resources.
+  Statements inside an open transaction are not retried individually, avoiding
+  replay of non-idempotent work.
+
+* **Transaction-safe metadata queries** — read-only relation, column, index,
+  freshness, and catalog queries no longer open transactions. This prevents
+  adapter introspection during operations such as
+  `dbt_external_tables.stage_external_sources` from accidentally owning and
+  rolling back subsequent DDL when the operation connection closes.
+
 * **Schema-aware full refreshes** — table models and incremental models running with
   `--full-refresh` preserve the existing table object when its ordered schema, identity
   properties, and `cluster_by` layout are unchanged. The adapter performs an atomic

--- a/dbt/adapters/fabric/__version__.py
+++ b/dbt/adapters/fabric/__version__.py
@@ -1,1 +1,1 @@
-version = "1.11.1"
+version = "1.11.2rc1"

--- a/dbt/adapters/fabric/base_connection_manager.py
+++ b/dbt/adapters/fabric/base_connection_manager.py
@@ -1,9 +1,7 @@
 import abc
-from typing import Any
 
 import dbt_common.exceptions
 
-from dbt.adapters.contracts.connection import Connection
 from dbt.adapters.events.logging import AdapterLogger
 from dbt.adapters.fabric.base_credentials import BaseFabricCredentials
 from dbt.adapters.fabric.fabric_api_client import FabricApiClient
@@ -55,23 +53,3 @@ class BaseFabricConnectionManager(SQLConnectionManager, metaclass=abc.ABCMeta):
                 credentials.purview_endpoint, cls.get_fabric_token_provider(credentials)
             )
         return cls._purview_client
-
-    # No transaction support
-    def begin(self):  # type: ignore
-        logger.debug("Not supported: begin")
-
-    def commit_if_has_connection(self) -> None:
-        logger.debug("Not supported: commit_if_has_connection")
-
-    @classmethod
-    def _rollback(cls, connection: Connection) -> None:  # type: ignore
-        logger.debug("Not supported: rollback")
-
-    def commit(self) -> None:  # type: ignore
-        logger.debug("Not supported: commit")
-
-    def add_begin_query(self, *args: Any, **kwargs: Any) -> None:  # type: ignore
-        logger.debug("Not supported: add_begin_query")
-
-    def add_commit_query(self, *args: Any, **kwargs: Any) -> None:  # type: ignore
-        logger.debug("Not supported: add_commit_query")

--- a/dbt/adapters/fabric/fabric_adapter.py
+++ b/dbt/adapters/fabric/fabric_adapter.py
@@ -19,6 +19,15 @@ from dbt.adapters.fabric.fabric_column import FabricColumn
 from dbt.adapters.fabric.fabric_configs import FabricConfigs
 from dbt.adapters.fabric.fabric_connection_manager import FabricConnectionManager
 from dbt.adapters.fabric.fabric_relation import FabricRelation
+from dbt.adapters.fabric.table_refresh import (
+    FabricTableColumn,
+    FabricTableConstraint,
+    build_refresh_plan,
+    desired_constraint,
+    diff_constraints,
+    query_references_relation,
+    requires_constraint_replacement,
+)
 from dbt.adapters.reference_keys import _make_ref_key_dict
 from dbt.adapters.sql.impl import CREATE_SCHEMA_MACRO_NAME, SQLAdapter
 
@@ -52,15 +61,269 @@ class FabricAdapter(BaseFabricAdapter, SQLAdapter):
     def get_column_schema_from_query(self, sql: str) -> list[BaseColumn]:
         """Get a list of the Columns with names and data types from the given sql."""
         _, cursor = self.connections.add_select_query(sql)
-
-        columns = [
+        return [
             self.Column.create(
-                column_name, self.connections.data_type_code_to_name(column_type_code)
+                column_name,
+                self.connections.data_type_code_to_name(column_type_code),
             )
-            # https://peps.python.org/pep-0249/#description
             for column_name, column_type_code, *_ in cursor.description
         ]
-        return columns
+
+    @available.parse(
+        lambda *a, **k: {
+            "action": "replace",
+            "reason": "parse-time default",
+            "column_names": [],
+            "constraints_to_drop": [],
+            "constraint_add_sql": [],
+        }
+    )
+    def get_table_refresh_plan(
+        self,
+        relation: BaseRelation,
+        sql: str,
+        cluster_by: str | list[str] | None = None,
+        constraints: list[object] | None = None,
+    ) -> dict[str, object]:
+        """Choose whether a full refresh can preserve the existing table object."""
+        query_columns = [
+            FabricTableColumn.from_column(column) for column in self._describe_query_columns(sql)
+        ]
+        target_columns = [
+            FabricTableColumn.from_column(column)
+            for column in self.get_columns_in_relation(relation)
+        ]
+        target_cluster_by = self._get_table_cluster_by(relation)
+        target_constraints = self.get_constraints_in_relation(relation)
+        raw_constraints = constraints or []
+        desired_constraints: list[FabricTableConstraint] = []
+        raw_constraints_by_name: dict[str, object] = {}
+        replacement_required = False
+        for constraint in raw_constraints:
+            replacement_required = replacement_required or requires_constraint_replacement(
+                constraint
+            )
+            parsed_constraint = desired_constraint(constraint)
+            if parsed_constraint is None:
+                continue
+            normalized_name = parsed_constraint.name.casefold()
+            if normalized_name in raw_constraints_by_name:
+                raise dbt_common.exceptions.DbtDatabaseError(
+                    f"Duplicate desired Fabric constraint name: {parsed_constraint.name}"
+                )
+            desired_constraints.append(parsed_constraint)
+            raw_constraints_by_name[normalized_name] = constraint
+
+        refresh_plan = build_refresh_plan(
+            query_columns,
+            target_columns,
+            cluster_by,
+            target_cluster_by,
+        )
+        constraints_to_drop, constraints_to_add = diff_constraints(
+            desired_constraints,
+            target_constraints,
+        )
+        refresh_plan["constraints_to_drop"] = constraints_to_drop
+        refresh_plan["constraints_to_add"] = constraints_to_add
+        refresh_plan["constraint_add_sql"] = [
+            rendered_constraint
+            for constraint_name in constraints_to_add
+            for rendered_constraint in self.render_raw_model_constraints(
+                raw_constraints=[raw_constraints_by_name[constraint_name.casefold()]]
+            )
+        ]
+        if refresh_plan["action"] == "reload" and replacement_required:
+            refresh_plan["action"] = "replace"
+            refresh_plan["reason"] = "constraint definition requires table replacement"
+        if refresh_plan["action"] == "reload" and query_references_relation(
+            sql,
+            [
+                str(relation),
+                str(relation.include(database=False)),
+            ],
+        ):
+            return {
+                "action": "replace",
+                "reason": "query references the target relation",
+                "column_names": [column.name for column in query_columns],
+                "constraints_to_drop": constraints_to_drop,
+                "constraints_to_add": constraints_to_add,
+                "constraint_add_sql": refresh_plan["constraint_add_sql"],
+            }
+        return refresh_plan
+
+    def _describe_query_columns(self, sql: str) -> list[FabricColumn]:
+        escaped_sql = sql.replace("'", "''")
+        rows = self._fetch_dicts(f"EXEC sys.sp_describe_first_result_set @tsql = N'{escaped_sql}'")
+        return [
+            FabricColumn(
+                column=str(row["name"]),
+                dtype=str(row["system_type_name"]).split("(", 1)[0],
+                char_size=self._column_character_size(
+                    str(row["system_type_name"]).split("(", 1)[0],
+                    row["max_length"],
+                ),
+                numeric_precision=row["precision"],
+                numeric_scale=row["scale"],
+                is_nullable=bool(row["is_nullable"]),
+                collation_name=(
+                    None if row["collation_name"] is None else str(row["collation_name"])
+                ),
+                is_identity=bool(row["is_identity_column"]),
+            )
+            for row in rows
+            if not row["is_hidden"]
+        ]
+
+    @staticmethod
+    def _column_character_size(data_type: str, max_length: object) -> int | None:
+        if max_length is None:
+            return None
+        if not isinstance(max_length, (int, str)):
+            raise TypeError(f"Unexpected max_length value: {max_length!r}")
+        size = int(max_length)
+        if data_type.casefold() in {"nchar", "nvarchar", "sysname"} and size != -1:
+            return size // 2
+        return size
+
+    def _get_table_cluster_by(self, relation: BaseRelation) -> list[str]:
+        relation_name = str(relation).replace("'", "''")
+        rows = self._fetch_dicts(
+            f"""
+            {self._use_database_sql(relation.database)}
+            SELECT c.name
+            FROM sys.columns AS c
+            INNER JOIN sys.index_columns AS ic
+                ON c.object_id = ic.object_id
+                AND c.column_id = ic.column_id
+            WHERE c.object_id = OBJECT_ID(N'{relation_name}')
+                AND ic.data_clustering_ordinal > 0
+            ORDER BY ic.data_clustering_ordinal
+            """
+        )
+        return [str(row["name"]) for row in rows]
+
+    @available.parse(lambda *a, **k: [])
+    def get_constraints_in_relation(self, relation: BaseRelation) -> list[FabricTableConstraint]:
+        """Return the named constraints defined on a Fabric table."""
+        relation_name = str(relation).replace("'", "''")
+        rows = self._fetch_dicts(
+            f"""
+            {self._use_database_sql(relation.database)}
+            SELECT
+                kc.name,
+                CASE kc.type WHEN 'PK' THEN 'primary_key' ELSE 'unique' END
+                    AS constraint_type,
+                c.name AS column_name,
+                ic.key_ordinal AS column_ordinal,
+                CAST(NULL AS varchar(128)) AS referenced_table,
+                CAST(NULL AS varchar(128)) AS referenced_schema,
+                CAST(NULL AS varchar(128)) AS referenced_database,
+                CAST(NULL AS varchar(128)) AS referenced_column
+            FROM sys.key_constraints AS kc
+            INNER JOIN sys.index_columns AS ic
+                ON kc.parent_object_id = ic.object_id
+                AND kc.unique_index_id = ic.index_id
+            INNER JOIN sys.columns AS c
+                ON ic.object_id = c.object_id
+                AND ic.column_id = c.column_id
+            WHERE kc.parent_object_id = OBJECT_ID(N'{relation_name}')
+            UNION ALL
+            SELECT
+                fk.name,
+                'foreign_key',
+                parent_column.name,
+                fkc.constraint_column_id,
+                referenced_table.name,
+                referenced_schema.name,
+                DB_NAME(),
+                referenced_column.name
+            FROM sys.foreign_keys AS fk
+            INNER JOIN sys.foreign_key_columns AS fkc
+                ON fk.object_id = fkc.constraint_object_id
+            INNER JOIN sys.columns AS parent_column
+                ON fkc.parent_object_id = parent_column.object_id
+                AND fkc.parent_column_id = parent_column.column_id
+            INNER JOIN sys.tables AS referenced_table
+                ON fkc.referenced_object_id = referenced_table.object_id
+            INNER JOIN sys.schemas AS referenced_schema
+                ON referenced_table.schema_id = referenced_schema.schema_id
+            INNER JOIN sys.columns AS referenced_column
+                ON fkc.referenced_object_id = referenced_column.object_id
+                AND fkc.referenced_column_id = referenced_column.column_id
+            WHERE fk.parent_object_id = OBJECT_ID(N'{relation_name}')
+            ORDER BY name, column_ordinal
+            """
+        )
+        grouped: dict[
+            str,
+            tuple[
+                str,
+                list[str],
+                str | None,
+                str | None,
+                str | None,
+                list[str],
+            ],
+        ] = {}
+        for row in rows:
+            name = str(row["name"])
+            _, columns, _, _, _, referenced_columns = grouped.setdefault(
+                name,
+                (
+                    str(row["constraint_type"]),
+                    [],
+                    (
+                        None
+                        if row["referenced_database"] is None
+                        else str(row["referenced_database"])
+                    ),
+                    (None if row["referenced_schema"] is None else str(row["referenced_schema"])),
+                    (None if row["referenced_table"] is None else str(row["referenced_table"])),
+                    [],
+                ),
+            )
+            columns.append(str(row["column_name"]))
+            if row["referenced_column"] is not None:
+                referenced_columns.append(str(row["referenced_column"]))
+        return [
+            FabricTableConstraint(
+                name=name,
+                constraint_type=constraint_type,
+                columns=tuple(columns),
+                referenced_database=referenced_database,
+                referenced_schema=referenced_schema,
+                referenced_table=referenced_table,
+                referenced_columns=tuple(referenced_columns),
+            )
+            for name, (
+                constraint_type,
+                columns,
+                referenced_database,
+                referenced_schema,
+                referenced_table,
+                referenced_columns,
+            ) in grouped.items()
+        ]
+
+    def _fetch_dicts(self, sql: str) -> list[dict[str, object]]:
+        _, cursor = self.connections.add_select_query(sql)
+        try:
+            while cursor.description is None and cursor.nextset():
+                pass
+            if cursor.description is None:
+                return []
+            fields = [str(description[0]).casefold() for description in cursor.description]
+            return [dict(zip(fields, row, strict=True)) for row in cursor.fetchall()]
+        finally:
+            cursor.close()
+
+    @classmethod
+    def _use_database_sql(cls, database: str | None) -> str:
+        if database is None:
+            return ""
+        return f"USE {cls.quote(database)};"
 
     @classmethod
     def convert_boolean_type(cls, agate_table, col_idx):

--- a/dbt/adapters/fabric/fabric_column.py
+++ b/dbt/adapters/fabric/fabric_column.py
@@ -1,9 +1,15 @@
+from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from dbt.adapters.base.column import Column
 
 
+@dataclass(eq=False, repr=False)
 class FabricColumn(Column):
+    is_nullable: bool | None = None
+    collation_name: str | None = None
+    is_identity: bool = False
+
     TYPE_LABELS: ClassVar[dict[str, str]] = {
         "BINARY": "BINARY(1)",
         "BOOLEAN": "BIT",

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -1,15 +1,20 @@
 import datetime as dt
 import re
 import struct
+import traceback
 from contextlib import contextmanager
 from typing import Any
 
 import agate
 import dbt_common.exceptions
 from dbt_common.clients.agate_helper import empty_table
+from dbt_common.events.contextvars import get_node_info
+from dbt_common.events.functions import fire_event
+from dbt_common.utils.casting import cast_to_str
 
 from dbt.adapters.contracts.connection import AdapterResponse, Connection, ConnectionState
 from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.events.types import RollbackFailed
 from dbt.adapters.fabric.base_connection_manager import BaseFabricConnectionManager
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
 
@@ -100,9 +105,8 @@ class FabricConnectionManager(BaseFabricConnectionManager):
             logger.debug(f"Database error: {str(e)}")
 
             try:
-                # attempt to release the connection
                 self.release()
-            except mssql_python.Error:
+            except Exception:
                 logger.debug("Failed to release connection!")
 
             raise dbt_common.exceptions.DbtDatabaseError(str(e).strip()) from e
@@ -307,7 +311,7 @@ class FabricConnectionManager(BaseFabricConnectionManager):
         return datatypes[data_type]
 
     def execute(
-        self, sql: str, auto_begin: bool = True, fetch: bool = False, limit: int | None = None
+        self, sql: str, auto_begin: bool = False, fetch: bool = False, limit: int | None = None
     ) -> tuple[AdapterResponse, agate.Table]:
         sql = self._add_query_comment(sql)
         _, cursor = self.add_query(sql, auto_begin)
@@ -327,6 +331,30 @@ class FabricConnectionManager(BaseFabricConnectionManager):
         response = self.get_response(cursor)
         return response, table
 
+    def add_begin_query(self):
+        return self.add_query("BEGIN TRANSACTION", auto_begin=False)
+
+    def add_commit_query(self):
+        return self.add_query("IF @@TRANCOUNT > 0 COMMIT TRANSACTION", auto_begin=False)
+
+    @classmethod
+    def _rollback_handle(cls, connection: Connection) -> None:
+        cursor = None
+        try:
+            cursor = connection.handle.cursor()
+            cursor.execute("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION")
+        except Exception:
+            fire_event(
+                RollbackFailed(
+                    conn_name=cast_to_str(connection.name),
+                    exc_info=traceback.format_exc(),
+                    node_info=get_node_info(),
+                )
+            )
+        finally:
+            if cursor is not None:
+                cursor.close()
+
     def add_query(
         self,
         sql: str,
@@ -345,6 +373,11 @@ class FabricConnectionManager(BaseFabricConnectionManager):
             bindings = ()
         else:
             bindings = [b.isoformat() if isinstance(b, dt.datetime) else b for b in bindings]
+
+        connection = self.get_thread_connection()
+        if auto_begin or connection.transaction_open:
+            retry_limit = 1
+
         return super().add_query(
             sql, auto_begin, bindings, abridge_sql_log, retryable_exceptions, retry_limit
         )

--- a/dbt/adapters/fabric/fabric_connection_manager.py
+++ b/dbt/adapters/fabric/fabric_connection_manager.py
@@ -179,7 +179,6 @@ class FabricConnectionManager(BaseFabricConnectionManager):
         if credentials.authentication == "ActiveDirectoryServicePrincipal":
             con_str.append(f"UID={{{credentials.client_id}}}")
             con_str.append(f"PWD={{{credentials.client_secret}}}")
-            con_str.append(f"Authority Id={{{credentials.tenant_id}}}")
 
         # https://docs.microsoft.com/en-us/sql/relational-databases/native-client/features/using-encryption-without-validation?view=sql-server-ver15
         assert credentials.encrypt is not None

--- a/dbt/adapters/fabric/fabric_relation.py
+++ b/dbt/adapters/fabric/fabric_relation.py
@@ -10,7 +10,7 @@ from dbt.adapters.utils import classproperty
 class FabricRelation(BaseRelation):
     type: FabricRelationType | None = None  # type: ignore
     quote_policy: FabricQuotePolicy = field(default_factory=lambda: FabricQuotePolicy())
-    require_alias: bool = True
+    require_alias: bool = False
 
     def quoted(self, identifier):
         return "[{}]".format(identifier.replace("]", "]]"))
@@ -24,6 +24,6 @@ class FabricRelation(BaseRelation):
         if self.limit is None:
             return rendered
         elif self.limit == 0:
-            return f"(select * from {rendered} where 1=0) AS {self._render_limited_alias()}"
+            return f"(select * from {rendered} where 1=0){self._render_limited_alias()}"
         else:
-            return f"(select TOP {self.limit} * from {rendered}) AS {self._render_limited_alias()}"
+            return f"(select TOP {self.limit} * from {rendered}){self._render_limited_alias()}"

--- a/dbt/adapters/fabric/fabric_relation.py
+++ b/dbt/adapters/fabric/fabric_relation.py
@@ -10,7 +10,7 @@ from dbt.adapters.utils import classproperty
 class FabricRelation(BaseRelation):
     type: FabricRelationType | None = None  # type: ignore
     quote_policy: FabricQuotePolicy = field(default_factory=lambda: FabricQuotePolicy())
-    require_alias: bool = False
+    require_alias: bool = True
 
     def quoted(self, identifier):
         return "[{}]".format(identifier.replace("]", "]]"))

--- a/dbt/adapters/fabric/table_refresh.py
+++ b/dbt/adapters/fabric/table_refresh.py
@@ -1,0 +1,365 @@
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from dbt_common.exceptions import DbtDatabaseError
+
+from dbt.adapters.fabric.fabric_column import FabricColumn
+
+
+@dataclass(frozen=True)
+class FabricTableColumn:
+    name: str
+    data_type: str
+    max_length: int | None
+    precision: int | None
+    scale: int | None
+    nullable: bool
+    collation: str | None
+    identity: bool
+
+    @classmethod
+    def from_column(cls, column: FabricColumn) -> "FabricTableColumn":
+        return cls(
+            name=column.name,
+            data_type=column.dtype.casefold(),
+            max_length=_optional_int(column.char_size),
+            precision=_optional_int(column.numeric_precision),
+            scale=_optional_int(column.numeric_scale),
+            nullable=bool(column.is_nullable),
+            collation=_optional_casefold(column.collation_name),
+            identity=column.is_identity,
+        )
+
+    @classmethod
+    def from_mapping(cls, value: dict[str, Any]) -> "FabricTableColumn":
+        return cls(
+            name=str(value["name"]),
+            data_type=str(value["data_type"]).casefold(),
+            max_length=_optional_int(value.get("max_length")),
+            precision=_optional_int(value.get("precision")),
+            scale=_optional_int(value.get("scale")),
+            nullable=bool(value.get("is_nullable")),
+            collation=_optional_casefold(value.get("collation_name")),
+            identity=bool(value.get("is_identity")),
+        )
+
+    @property
+    def comparison_key(self) -> tuple[Any, ...]:
+        return (
+            self.name.casefold(),
+            self.data_type,
+            self.max_length,
+            self.precision,
+            self.scale,
+            self.nullable,
+            self.collation,
+            self.identity,
+        )
+
+    def can_reload_into(self, target: "FabricTableColumn") -> bool:
+        query_definition = self.comparison_key[:5] + self.comparison_key[6:]
+        target_definition = target.comparison_key[:5] + target.comparison_key[6:]
+        if query_definition != target_definition:
+            return False
+
+        # Query metadata often marks expressions nullable even when a model contract
+        # creates a NOT NULL target. Keeping the stricter target is safe; the insert
+        # still fails and rolls back if the query actually produces NULL.
+        return not (target.nullable and not self.nullable)
+
+
+@dataclass(frozen=True)
+class FabricTableConstraint:
+    name: str
+    constraint_type: str
+    columns: tuple[str, ...]
+    referenced_database: str | None = None
+    referenced_schema: str | None = None
+    referenced_table: str | None = None
+    referenced_columns: tuple[str, ...] = ()
+
+    @property
+    def comparison_key(self) -> tuple[Any, ...]:
+        return (
+            self.name.casefold(),
+            self.constraint_type.casefold(),
+            tuple(column.casefold() for column in self.columns),
+            _optional_casefold(self.referenced_database),
+            _optional_casefold(self.referenced_schema),
+            _optional_casefold(self.referenced_table),
+            tuple(column.casefold() for column in self.referenced_columns),
+        )
+
+
+def build_refresh_plan(
+    query_columns: list[FabricTableColumn],
+    target_columns: list[FabricTableColumn],
+    requested_cluster_by: str | list[str] | None,
+    target_cluster_by: list[str],
+) -> dict[str, Any]:
+    if any(column.identity for column in query_columns + target_columns):
+        return _replace_plan("identity column present", query_columns)
+
+    if len(query_columns) != len(target_columns):
+        return _replace_plan("column count changed", query_columns)
+
+    for query_column, target_column in zip(query_columns, target_columns, strict=True):
+        if not query_column.can_reload_into(target_column):
+            return _replace_plan(
+                f"column definition changed for {query_column.name}",
+                query_columns,
+            )
+
+    requested_cluster_columns = [
+        column.casefold() for column in _normalize_cluster_by(requested_cluster_by)
+    ]
+    target_cluster_columns = [column.casefold() for column in target_cluster_by]
+    if requested_cluster_columns != target_cluster_columns:
+        return _replace_plan("physical layout changed", query_columns)
+
+    return {
+        "action": "reload",
+        "reason": "schema and physical layout unchanged",
+        "column_names": [column.name for column in query_columns],
+    }
+
+
+def diff_constraints(
+    desired: list[FabricTableConstraint],
+    existing: list[FabricTableConstraint],
+) -> tuple[list[str], list[str]]:
+    desired_by_name = _constraints_by_name(desired, "desired")
+    existing_by_name = _constraints_by_name(existing, "existing")
+
+    to_drop = sorted(
+        (
+            constraint.name
+            for name, constraint in existing_by_name.items()
+            if name not in desired_by_name
+            or not _constraints_equal(desired_by_name[name], constraint)
+        ),
+        key=str.casefold,
+    )
+    to_add = sorted(
+        (
+            constraint.name
+            for name, constraint in desired_by_name.items()
+            if name not in existing_by_name
+            or not _constraints_equal(constraint, existing_by_name[name])
+        ),
+        key=str.casefold,
+    )
+    return to_drop, to_add
+
+
+def desired_constraint(value: Any) -> FabricTableConstraint | None:
+    constraint_type = _constraint_value(value, "type")
+    if constraint_type is None:
+        return None
+
+    normalized_type = str(getattr(constraint_type, "value", constraint_type)).casefold()
+    if normalized_type not in {"primary_key", "unique", "foreign_key"}:
+        return None
+
+    name = _constraint_value(value, "name")
+    if name is None or not str(name).strip():
+        raise DbtDatabaseError(f"Fabric {normalized_type} constraints must have a non-empty name.")
+
+    columns = tuple(str(column) for column in (_constraint_value(value, "columns") or []))
+    if not columns or any(not column.strip() for column in columns):
+        raise DbtDatabaseError(
+            f"Fabric constraint {name!s} must define at least one non-empty column."
+        )
+
+    referenced_database = None
+    referenced_schema = None
+    referenced_table = None
+    referenced_columns: tuple[str, ...] = ()
+    if normalized_type == "foreign_key":
+        expression = _constraint_value(value, "expression")
+        if expression is None:
+            return None
+        (
+            referenced_database,
+            referenced_schema,
+            referenced_table,
+            referenced_columns,
+        ) = _parse_reference(expression)
+        if len(referenced_columns) != len(columns):
+            raise DbtDatabaseError(
+                f"Fabric foreign key constraint {name!s} has {len(columns)} source "
+                f"columns but {len(referenced_columns)} referenced columns."
+            )
+
+    return FabricTableConstraint(
+        name=str(name),
+        constraint_type=normalized_type,
+        columns=columns,
+        referenced_database=referenced_database,
+        referenced_schema=referenced_schema,
+        referenced_table=referenced_table,
+        referenced_columns=referenced_columns,
+    )
+
+
+def requires_constraint_replacement(value: Any) -> bool:
+    constraint_type = _constraint_value(value, "type")
+    normalized_type = str(getattr(constraint_type, "value", constraint_type)).casefold()
+    return normalized_type == "custom" and bool(_constraint_value(value, "expression"))
+
+
+def _constraints_by_name(
+    constraints: list[FabricTableConstraint],
+    source: str,
+) -> dict[str, FabricTableConstraint]:
+    by_name: dict[str, FabricTableConstraint] = {}
+    for constraint in constraints:
+        normalized_name = constraint.name.casefold()
+        if normalized_name in by_name:
+            raise DbtDatabaseError(f"Duplicate {source} Fabric constraint name: {constraint.name}")
+        by_name[normalized_name] = constraint
+    return by_name
+
+
+def _constraints_equal(
+    desired: FabricTableConstraint,
+    existing: FabricTableConstraint,
+) -> bool:
+    if (
+        desired.name.casefold() != existing.name.casefold()
+        or desired.constraint_type.casefold() != existing.constraint_type.casefold()
+        or _normalized_identifiers(desired.columns) != _normalized_identifiers(existing.columns)
+        or _optional_casefold(desired.referenced_table)
+        != _optional_casefold(existing.referenced_table)
+        or _normalized_identifiers(desired.referenced_columns)
+        != _normalized_identifiers(existing.referenced_columns)
+    ):
+        return False
+
+    if desired.referenced_schema is not None and _optional_casefold(
+        desired.referenced_schema
+    ) != _optional_casefold(existing.referenced_schema):
+        return False
+    return not (
+        desired.referenced_database is not None
+        and _optional_casefold(desired.referenced_database)
+        != _optional_casefold(existing.referenced_database)
+    )
+
+
+def _normalized_identifiers(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(value.casefold() for value in values)
+
+
+def _parse_reference(
+    expression: Any,
+) -> tuple[str | None, str | None, str, tuple[str, ...]]:
+    normalized = str(expression).strip()
+    opening_parenthesis = normalized.find("(")
+    if opening_parenthesis <= 0 or not normalized.endswith(")"):
+        raise DbtDatabaseError(
+            "Fabric foreign key expressions must use '[database.][schema.]table (column[, ...])'."
+        )
+
+    relation_text = normalized[:opening_parenthesis].strip()
+    columns_text = normalized[opening_parenthesis + 1 : -1].strip()
+    relation_parts = _split_sql_identifiers(relation_text, ".")
+    if not 1 <= len(relation_parts) <= 3:
+        raise DbtDatabaseError(
+            "Fabric foreign key references must contain a table and optional schema and database."
+        )
+    referenced_columns = tuple(_split_sql_identifiers(columns_text, ","))
+    if not referenced_columns:
+        raise DbtDatabaseError("Fabric foreign key expressions must define referenced columns.")
+
+    database = relation_parts[-3] if len(relation_parts) == 3 else None
+    schema = relation_parts[-2] if len(relation_parts) >= 2 else None
+    return database, schema, relation_parts[-1], referenced_columns
+
+
+def _split_sql_identifiers(value: str, separator: str) -> list[str]:
+    identifiers: list[str] = []
+    token: list[str] = []
+    in_brackets = False
+    quoted = False
+    bracket_closed = False
+    index = 0
+    while index < len(value):
+        character = value[index]
+        if character == "[":
+            if in_brackets or quoted or "".join(token).strip():
+                raise _invalid_identifier_list(value)
+            in_brackets = True
+            quoted = True
+        elif character == "]" and in_brackets:
+            if index + 1 < len(value) and value[index + 1] == "]":
+                token.append("]")
+                index += 1
+            else:
+                in_brackets = False
+                bracket_closed = True
+        elif character == separator and not in_brackets:
+            identifiers.append(_validate_identifier("".join(token), value, quoted))
+            token = []
+            quoted = False
+            bracket_closed = False
+        elif bracket_closed and not character.isspace():
+            raise _invalid_identifier_list(value)
+        else:
+            token.append(character)
+        index += 1
+
+    if in_brackets:
+        raise _invalid_identifier_list(value)
+    identifiers.append(_validate_identifier("".join(token), value, quoted))
+    return identifiers
+
+
+def _validate_identifier(identifier: str, source: str, quoted: bool) -> str:
+    normalized = identifier.strip()
+    if not normalized or (not quoted and not re.fullmatch(r"[\w@$#]+", normalized)):
+        raise _invalid_identifier_list(source)
+    return normalized
+
+
+def _invalid_identifier_list(value: str) -> DbtDatabaseError:
+    return DbtDatabaseError(
+        f"Invalid Fabric constraint identifier list: {value!r}. "
+        "Use bare or bracket-quoted identifiers."
+    )
+
+
+def _replace_plan(reason: str, columns: list[FabricTableColumn]) -> dict[str, Any]:
+    return {
+        "action": "replace",
+        "reason": reason,
+        "column_names": [column.name for column in columns],
+    }
+
+
+def _normalize_cluster_by(cluster_by: str | list[str] | None) -> list[str]:
+    if cluster_by is None:
+        return []
+    if isinstance(cluster_by, str):
+        return [cluster_by]
+    return list(cluster_by)
+
+
+def query_references_relation(sql: str, relation_names: list[str]) -> bool:
+    normalized_sql = sql.casefold()
+    return any(name.casefold() in normalized_sql for name in relation_names)
+
+
+def _constraint_value(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(name)
+    return getattr(value, name, None)
+
+
+def _optional_int(value: Any) -> int | None:
+    return None if value is None else int(value)
+
+
+def _optional_casefold(value: Any) -> str | None:
+    return None if value is None else str(value).casefold()

--- a/dbt/include/fabric/macros/adapters/catalog.sql
+++ b/dbt/include/fabric/macros/adapters/catalog.sql
@@ -1,6 +1,6 @@
 {% macro fabric__get_catalog(information_schemas, schemas) -%}
 
-    {%- call statement('catalog', fetch_result=True) -%}
+    {%- call statement('catalog', fetch_result=True, auto_begin=False) -%}
         {{ get_use_database_sql(information_schemas.database) }}
         with
         principals as (
@@ -133,7 +133,7 @@
     {%- set distinct_databases = relations | map(attribute='database') | unique | list -%}
 
     {%- if distinct_databases | length == 1 -%}
-        {%- call statement('catalog', fetch_result=True) -%}
+        {%- call statement('catalog', fetch_result=True, auto_begin=False) -%}
             {{ get_use_database_sql(distinct_databases[0]) }}
             with
             principals as (

--- a/dbt/include/fabric/macros/adapters/columns.sql
+++ b/dbt/include/fabric/macros/adapters/columns.sql
@@ -19,7 +19,10 @@
 					else c.max_length
 				end as character_maximum_length,
                 c.precision as numeric_precision,
-                c.scale as numeric_scale
+				c.scale as numeric_scale,
+				c.is_nullable,
+				c.collation_name,
+				c.is_identity
             from sys.columns c {{ information_schema_hints() }}
             inner join sys.types t {{ information_schema_hints() }}
             on c.user_type_id = t.user_type_id
@@ -31,7 +34,10 @@
             data_type,
             character_maximum_length,
             numeric_precision,
-            numeric_scale
+            numeric_scale,
+            is_nullable,
+            collation_name,
+            is_identity
         from mapping
         order by ordinal_position
 

--- a/dbt/include/fabric/macros/adapters/columns.sql
+++ b/dbt/include/fabric/macros/adapters/columns.sql
@@ -7,7 +7,11 @@
 {% endmacro %}
 
 {% macro fabric__get_columns_in_relation(relation) -%}
-    {% call statement('get_columns_in_relation', fetch_result=True) %}
+    {% call statement(
+        'get_columns_in_relation',
+        fetch_result=True,
+        auto_begin=False
+    ) %}
         {{ get_use_database_sql(relation.database) }}
         with mapping as (
             select

--- a/dbt/include/fabric/macros/adapters/indexes.sql
+++ b/dbt/include/fabric/macros/adapters/indexes.sql
@@ -19,7 +19,11 @@
 {% endmacro %}
 
 {% macro drop_fk_indexes_on_table(relation) -%}
-  {% call statement('find_references', fetch_result=true) %}
+  {% call statement(
+      'find_references',
+      fetch_result=true,
+      auto_begin=False
+  ) %}
       USE [{{ relation.database }}];
       SELECT  obj.name AS FK_NAME,
       sch.name AS [schema_name],
@@ -59,7 +63,11 @@
 {% endmacro %}
 
 {% macro fabric__list_nonclustered_rowstore_indexes(relation) -%}
-  {% call statement('list_nonclustered_rowstore_indexes', fetch_result=True) -%}
+  {% call statement(
+      'list_nonclustered_rowstore_indexes',
+      fetch_result=True,
+      auto_begin=False
+  ) -%}
 
     SELECT i.name AS index_name
     , i.name + '__dbt_backup' as index_new_name

--- a/dbt/include/fabric/macros/adapters/metadata.sql
+++ b/dbt/include/fabric/macros/adapters/metadata.sql
@@ -36,7 +36,11 @@
 {% endmacro %}
 
 {% macro fabric__list_relations_without_caching(schema_relation) -%}
-  {% call statement('list_relations_without_caching', fetch_result=True) -%}
+  {% call statement(
+      'list_relations_without_caching',
+      fetch_result=True,
+      auto_begin=False
+  ) -%}
     {{ get_use_database_sql(schema_relation.database) }}
     with base as (
       select
@@ -70,7 +74,11 @@
 {% endmacro %}
 
 {% macro fabric__list_function_relations_without_caching(schema_relation) %}
-  {% call statement('list_function_relations_without_caching', fetch_result=True) %}
+  {% call statement(
+      'list_function_relations_without_caching',
+      fetch_result=True,
+      auto_begin=False
+  ) %}
     {{ get_use_database_sql(schema_relation.database) }}
     select
         DB_NAME() as [database],
@@ -85,7 +93,11 @@
 {% endmacro %}
 
 {% macro fabric__get_relation_last_modified(information_schema, relations) -%}
-  {%- call statement('last_modified', fetch_result=True) -%}
+  {%- call statement(
+      'last_modified',
+      fetch_result=True,
+      auto_begin=False
+  ) -%}
         {{ get_use_database_sql(information_schema.database) }}
         select
             o.name as [identifier]

--- a/dbt/include/fabric/macros/adapters/relation.sql
+++ b/dbt/include/fabric/macros/adapters/relation.sql
@@ -1,6 +1,10 @@
 {% macro fabric__get_drop_sql(relation) -%}
   {% if relation.type == 'view' -%}
-      {% call statement('find_references', fetch_result=true) %}
+      {% call statement(
+          'find_references',
+          fetch_result=true,
+          auto_begin=False
+      ) %}
         {{ get_use_database_sql(relation.database) }}
         select
             sch.name as schema_name,

--- a/dbt/include/fabric/macros/materializations/functions/function.sql
+++ b/dbt/include/fabric/macros/materializations/functions/function.sql
@@ -1,0 +1,34 @@
+{% materialization function, adapter='fabric', supported_languages=['sql', 'python'] %}
+    {% set existing_relation = load_cached_relation(this) %}
+    {% set target_relation = this.incorporate(type=this.Function) %}
+    {% set grant_config = config.get('grants') %}
+
+    {{ run_hooks(pre_hooks, inside_transaction=False) }}
+    {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+    {% set function_config = this.get_function_config(model) %}
+    {% set macro_name = this.get_function_macro_name(function_config) %}
+    {% set _dispatch = adapter.dispatch %}
+    {% set build_sql = _dispatch(macro_name, 'dbt')(target_relation) %}
+
+    {% call statement(name='main') %}
+        {{ build_sql }}
+    {% endcall %}
+
+    {% set should_revoke = should_revoke(
+        existing_relation,
+        full_refresh_mode=True
+    ) %}
+    {% do apply_grants(
+        target_relation,
+        grant_config,
+        should_revoke=should_revoke
+    ) %}
+    {% do persist_docs(target_relation, model) %}
+
+    {{ run_hooks(post_hooks, inside_transaction=True) }}
+    {% do adapter.commit() %}
+    {{ run_hooks(post_hooks, inside_transaction=False) }}
+
+    {{ return({'relations': [target_relation]}) }}
+{% endmaterialization %}

--- a/dbt/include/fabric/macros/materializations/hooks.sql
+++ b/dbt/include/fabric/macros/materializations/hooks.sql
@@ -1,11 +1,5 @@
 {% macro run_hooks(hooks, inside_transaction=True) %}
   {% for hook in hooks | selectattr('transaction', 'equalto', inside_transaction)  %}
-    {# For now we don't support transactions #}
-    {# {% if not inside_transaction and loop.first %}
-      {% call statement(auto_begin=inside_transaction) %}
-        commit;
-      {% endcall %}
-    {% endif %} #}
     {% set rendered = render(hook.get('sql')) | trim %}
     {% if (rendered | length) > 0 %}
       {% call statement(auto_begin=inside_transaction) %}

--- a/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -33,19 +33,12 @@
   {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = load_cached_relation(this) -%}
 
-  {# Can't overwrite a view with a table - we must drop #}
-  {% if existing_relation is not none and existing_relation.type == 'view' %}
-    {{ log("Dropping relation " ~ existing_relation ~ " because it is a view and target is a table.") }}
-    {% do adapter.drop_relation(existing_relation) %}
-    {%- set existing_relation = none -%}
-  {% endif %}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {# `BEGIN` happens here: #}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
   {# Full rebuild when no target table exists or full refresh requested #}
-  {% if existing_relation is none or full_refresh_mode %}
+  {% if existing_relation is none or full_refresh_mode or existing_relation.type == 'view' %}
 
     {% set refresh_plan = fabric_full_refresh_table(
         target_relation,
@@ -100,9 +93,6 @@
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
   {% do persist_docs(target_relation, model) %}
 
-  {# `COMMIT` happens here #}
-  {% do adapter.commit() %}
-
   {# Add or reconcile constraints including FK relations. #}
   {% if full_refresh_mode and refresh_plan['action'] == 'reload' %}
     {{ reconcile_model_constraints(target_relation, refresh_plan) }}
@@ -116,6 +106,10 @@
           or (full_refresh_mode and refresh_plan['action'] == 'reload')
       )
   ) }}
+
+  {# `COMMIT` happens here #}
+  {% do adapter.commit() %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
+++ b/dbt/include/fabric/macros/materializations/models/incremental/incremental.sql
@@ -47,30 +47,12 @@
   {# Full rebuild when no target table exists or full refresh requested #}
   {% if existing_relation is none or full_refresh_mode %}
 
-    {# Set up intermediate and backup relations #}
-    {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
-    {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
-    {%- set backup_relation = make_backup_relation(target_relation, 'table') -%}
-    {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-
-    {{ drop_relation_if_exists(preexisting_backup_relation) }}
-    {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
-
-    {# Build model into intermediate relation #}
-    {%- call statement('main', language=language) -%}
-      {{ create_table_as(False, intermediate_relation, compiled_code, language) }}
-    {%- endcall -%}
-
-    {% do create_indexes(intermediate_relation) %}
-
-    {# Swap: rename existing → backup, intermediate → target, then drop backup #}
-    {% if existing_relation is not none %}
-      {{ adapter.rename_relation(existing_relation, backup_relation) }}
-      {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-      {{ adapter.drop_relation(backup_relation) }}
-    {% else %}
-      {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-    {% endif %}
+    {% set refresh_plan = fabric_full_refresh_table(
+        target_relation,
+        existing_relation,
+        compiled_code,
+        language
+    ) %}
 
   {# Incremental merge into existing target table #}
   {% else %}
@@ -121,9 +103,19 @@
   {# `COMMIT` happens here #}
   {% do adapter.commit() %}
 
-  {# Add constraints including FK relation #}
-  {{ build_model_constraints(target_relation) }}
-  {{ create_or_update_statistics(target_relation, existing_table=(existing_relation is not none and not full_refresh_mode)) }}
+  {# Add or reconcile constraints including FK relations. #}
+  {% if full_refresh_mode and refresh_plan['action'] == 'reload' %}
+    {{ reconcile_model_constraints(target_relation, refresh_plan) }}
+  {% else %}
+    {{ build_model_constraints(target_relation) }}
+  {% endif %}
+  {{ create_or_update_statistics(
+      target_relation,
+      existing_table=(
+          (existing_relation is not none and not full_refresh_mode)
+          or (full_refresh_mode and refresh_plan['action'] == 'reload')
+      )
+  ) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
 
   {{ return({'relations': [target_relation]}) }}

--- a/dbt/include/fabric/macros/materializations/models/table/clone.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/clone.sql
@@ -7,3 +7,78 @@
     CREATE TABLE {{target_relation}}
     AS CLONE OF {{defer_relation}}
 {% endmacro %}
+
+{% materialization clone, adapter='fabric' %}
+
+  {%- set relations = {'relations': []} -%}
+
+  {%- if not defer_relation -%}
+    {{ log("No relation found in state manifest for " ~ model.unique_id, info=True) }}
+    {{ return(relations) }}
+  {%- endif -%}
+
+  {%- set existing_relation = load_cached_relation(this) -%}
+
+  {%- if existing_relation and not flags.FULL_REFRESH -%}
+    {{ log("Relation " ~ existing_relation ~ " already exists", info=True) }}
+    {{ return(relations) }}
+  {%- endif -%}
+
+  {%- set other_existing_relation = load_cached_relation(defer_relation) -%}
+  {%- set can_clone_table = can_clone_table() -%}
+  {%- set grant_config = config.get('grants') -%}
+
+  {%- if other_existing_relation
+        and other_existing_relation.type == 'table'
+        and can_clone_table -%}
+
+    {%- set target_relation = this.incorporate(type='table') -%}
+    {% if existing_relation is not none and not existing_relation.is_table %}
+      {{ log(
+          "Dropping relation " ~ existing_relation.render()
+          ~ " because it is of type " ~ existing_relation.type
+      ) }}
+      {{ drop_relation_if_exists(existing_relation) }}
+    {% endif %}
+
+    {% if target_relation.database == defer_relation.database
+          and target_relation.schema == defer_relation.schema
+          and target_relation.identifier == defer_relation.identifier %}
+      {{ log(
+          "Target relation and defer relation are the same, skipping clone for relation: "
+          ~ target_relation.render()
+      ) }}
+    {% else %}
+      {% call statement('main') %}
+        {{ create_or_replace_clone(target_relation, defer_relation) }}
+      {% endcall %}
+
+      {% set should_revoke = should_revoke(
+          existing_relation,
+          full_refresh_mode=True
+      ) %}
+      {% do apply_grants(
+          target_relation,
+          grant_config,
+          should_revoke=should_revoke
+      ) %}
+      {% do persist_docs(target_relation, model) %}
+      {% do adapter.commit() %}
+    {% endif %}
+
+    {{ return({'relations': [target_relation]}) }}
+
+  {%- else -%}
+
+    {%- set target_relation = this.incorporate(type='view') -%}
+    {% set search_name = "materialization_view_" ~ adapter.type() %}
+    {% if not search_name in context %}
+      {% set search_name = "materialization_view_default" %}
+    {% endif %}
+    {% set materialization_macro = context[search_name] %}
+    {% set relations = materialization_macro() %}
+    {{ return(relations) }}
+
+  {%- endif -%}
+
+{% endmaterialization %}

--- a/dbt/include/fabric/macros/materializations/models/table/columns_spec_ddl.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/columns_spec_ddl.sql
@@ -28,3 +28,37 @@
       {%- endcall %}
     {% endfor -%}
 {% endmacro %}
+
+{% macro reconcile_model_constraints(relation, refresh_plan) %}
+    {{ return(adapter.dispatch('reconcile_model_constraints', 'dbt')(
+        relation,
+        refresh_plan
+    )) }}
+{% endmacro %}
+
+{% macro fabric__reconcile_model_constraints(relation, refresh_plan) %}
+  {% set constraints_to_drop = refresh_plan['constraints_to_drop'] %}
+  {% set constraint_add_sql = refresh_plan['constraint_add_sql'] %}
+  {% if constraints_to_drop or constraint_add_sql %}
+    {% call statement('reconcile_model_constraints', auto_begin=False) -%}
+      {{ get_use_database_sql(relation.database) }}
+      BEGIN TRY
+        BEGIN TRANSACTION;
+        {% for constraint_name in constraints_to_drop %}
+          ALTER TABLE {{ relation.include(database=False) }}
+          DROP CONSTRAINT {{ adapter.quote(constraint_name) }};
+        {% endfor %}
+        {% for rendered_constraint in constraint_add_sql %}
+          ALTER TABLE {{ relation.include(database=False) }}
+          {{ rendered_constraint }};
+        {% endfor %}
+        COMMIT TRANSACTION;
+      END TRY
+      BEGIN CATCH
+        IF @@TRANCOUNT > 0
+          ROLLBACK TRANSACTION;
+        THROW;
+      END CATCH;
+    {%- endcall %}
+  {% endif %}
+{% endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/columns_spec_ddl.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/columns_spec_ddl.sql
@@ -40,25 +40,16 @@
   {% set constraints_to_drop = refresh_plan['constraints_to_drop'] %}
   {% set constraint_add_sql = refresh_plan['constraint_add_sql'] %}
   {% if constraints_to_drop or constraint_add_sql %}
-    {% call statement('reconcile_model_constraints', auto_begin=False) -%}
+    {% call statement('reconcile_model_constraints') -%}
       {{ get_use_database_sql(relation.database) }}
-      BEGIN TRY
-        BEGIN TRANSACTION;
-        {% for constraint_name in constraints_to_drop %}
-          ALTER TABLE {{ relation.include(database=False) }}
-          DROP CONSTRAINT {{ adapter.quote(constraint_name) }};
-        {% endfor %}
-        {% for rendered_constraint in constraint_add_sql %}
-          ALTER TABLE {{ relation.include(database=False) }}
-          {{ rendered_constraint }};
-        {% endfor %}
-        COMMIT TRANSACTION;
-      END TRY
-      BEGIN CATCH
-        IF @@TRANCOUNT > 0
-          ROLLBACK TRANSACTION;
-        THROW;
-      END CATCH;
+      {% for constraint_name in constraints_to_drop %}
+        ALTER TABLE {{ relation.include(database=False) }}
+        DROP CONSTRAINT {{ adapter.quote(constraint_name) }};
+      {% endfor %}
+      {% for rendered_constraint in constraint_add_sql %}
+        ALTER TABLE {{ relation.include(database=False) }}
+        {{ rendered_constraint }};
+      {% endfor %}
     {%- endcall %}
   {% endif %}
 {% endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/refresh.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/refresh.sql
@@ -1,0 +1,161 @@
+{% macro fabric_full_refresh_table(target_relation, existing_relation, compiled_code, language) %}
+  {{ return(adapter.dispatch('full_refresh_table', 'dbt')(
+      target_relation,
+      existing_relation,
+      compiled_code,
+      language
+  )) }}
+{% endmacro %}
+
+{% macro fabric__full_refresh_table(target_relation, existing_relation, compiled_code, language) %}
+  {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
+  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
+  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
+
+  {%- set backup_relation_type = (
+      'table' if existing_relation is none else existing_relation.type
+  ) -%}
+  {%- set backup_relation = make_backup_relation(
+      target_relation,
+      backup_relation_type
+  ) -%}
+  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
+  {{ drop_relation_if_exists(preexisting_backup_relation) }}
+
+  {%- if existing_relation is not none and existing_relation.type == 'table' -%}
+    {%- set refresh_plan = adapter.get_table_refresh_plan(
+        existing_relation,
+        compiled_code,
+        config.get('cluster_by'),
+        model['constraints']
+    ) -%}
+  {%- elif existing_relation is not none -%}
+    {%- set refresh_plan = {
+        'action': 'legacy_replace',
+        'reason': 'relation type changed',
+        'column_names': [],
+        'constraints_to_drop': [],
+        'constraints_to_add': [],
+        'constraint_add_sql': []
+    } -%}
+  {%- else -%}
+    {%- set refresh_plan = {
+        'action': 'replace',
+        'reason': 'target table does not exist',
+        'column_names': [],
+        'constraints_to_drop': [],
+        'constraints_to_add': [],
+        'constraint_add_sql': []
+    } -%}
+  {%- endif -%}
+
+  {{ log(
+      'Fabric full refresh for ' ~ target_relation ~ ': '
+      ~ refresh_plan['action'] ~ ' (' ~ refresh_plan['reason'] ~ ')',
+      info=True
+  ) }}
+
+  {% if refresh_plan['action'] == 'reload' %}
+    {% call statement('main', language=language, auto_begin=False) -%}
+      {{ fabric_atomic_reload_sql(
+          target_relation,
+          compiled_code,
+          refresh_plan['column_names']
+      ) }}
+    {%- endcall %}
+  {% elif refresh_plan['action'] == 'replace' %}
+    {% set create_sql = create_table_as(
+        False,
+        intermediate_relation,
+        compiled_code,
+        language
+    ) %}
+    {% call statement('main', language=language, auto_begin=False) -%}
+      {{ fabric_atomic_replace_sql(
+          target_relation,
+          existing_relation,
+          intermediate_relation,
+          create_sql
+      ) }}
+    {%- endcall %}
+    {% do create_indexes(target_relation) %}
+  {% else %}
+    {% call statement('main', language=language) -%}
+      {{ create_table_as(False, intermediate_relation, compiled_code, language) }}
+    {%- endcall %}
+    {% do create_indexes(intermediate_relation) %}
+    {{ adapter.rename_relation(existing_relation, backup_relation) }}
+    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
+    {{ adapter.drop_relation(backup_relation) }}
+  {% endif %}
+
+  {{ return(refresh_plan) }}
+{% endmacro %}
+
+{% macro fabric_atomic_reload_sql(target_relation, compiled_code, column_names) %}
+  {{ return(adapter.dispatch('atomic_reload_sql', 'dbt')(
+      target_relation,
+      compiled_code,
+      column_names
+  )) }}
+{% endmacro %}
+
+{% macro fabric__atomic_reload_sql(target_relation, compiled_code, column_names) %}
+  {%- set quoted_columns = [] -%}
+  {%- for column_name in column_names -%}
+    {%- do quoted_columns.append(adapter.quote(column_name)) -%}
+  {%- endfor -%}
+  {{ get_use_database_sql(target_relation.database) }}
+  BEGIN TRY
+    BEGIN TRANSACTION;
+    TRUNCATE TABLE {{ target_relation.include(database=False) }};
+    INSERT INTO {{ target_relation.include(database=False) }}
+      ({{ quoted_columns | join(', ') }})
+    {{ compiled_code }};
+    COMMIT TRANSACTION;
+  END TRY
+  BEGIN CATCH
+    IF @@TRANCOUNT > 0
+      ROLLBACK TRANSACTION;
+    THROW;
+  END CATCH;
+{% endmacro %}
+
+{% macro fabric_atomic_replace_sql(
+    target_relation,
+    existing_relation,
+    intermediate_relation,
+    create_sql
+) %}
+  {{ return(adapter.dispatch('atomic_replace_sql', 'dbt')(
+      target_relation,
+      existing_relation,
+      intermediate_relation,
+      create_sql
+  )) }}
+{% endmacro %}
+
+{% macro fabric__atomic_replace_sql(
+    target_relation,
+    existing_relation,
+    intermediate_relation,
+    create_sql
+) %}
+  {{ get_use_database_sql(target_relation.database) }}
+  BEGIN TRY
+    BEGIN TRANSACTION;
+    {{ create_sql }}
+    {% if existing_relation is not none %}
+      DROP {{ existing_relation.type }} {{ existing_relation.include(database=False) }};
+    {% endif %}
+    EXEC sp_rename
+      '{{ intermediate_relation.include(database=False) | replace("'", "''") }}',
+      '{{ target_relation.identifier | replace("'", "''") }}';
+    COMMIT TRANSACTION;
+  END TRY
+  BEGIN CATCH
+    IF @@TRANCOUNT > 0
+      ROLLBACK TRANSACTION;
+    THROW;
+  END CATCH;
+{% endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/refresh.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/refresh.sql
@@ -56,7 +56,7 @@
   ) }}
 
   {% if refresh_plan['action'] == 'reload' %}
-    {% call statement('main', language=language, auto_begin=False) -%}
+    {% call statement('main', language=language) -%}
       {{ fabric_atomic_reload_sql(
           target_relation,
           compiled_code,
@@ -70,7 +70,7 @@
         compiled_code,
         language
     ) %}
-    {% call statement('main', language=language, auto_begin=False) -%}
+    {% call statement('main', language=language) -%}
       {{ fabric_atomic_replace_sql(
           target_relation,
           existing_relation,
@@ -106,19 +106,10 @@
     {%- do quoted_columns.append(adapter.quote(column_name)) -%}
   {%- endfor -%}
   {{ get_use_database_sql(target_relation.database) }}
-  BEGIN TRY
-    BEGIN TRANSACTION;
-    TRUNCATE TABLE {{ target_relation.include(database=False) }};
-    INSERT INTO {{ target_relation.include(database=False) }}
-      ({{ quoted_columns | join(', ') }})
-    {{ compiled_code }};
-    COMMIT TRANSACTION;
-  END TRY
-  BEGIN CATCH
-    IF @@TRANCOUNT > 0
-      ROLLBACK TRANSACTION;
-    THROW;
-  END CATCH;
+  TRUNCATE TABLE {{ target_relation.include(database=False) }};
+  INSERT INTO {{ target_relation.include(database=False) }}
+    ({{ quoted_columns | join(', ') }})
+  {{ compiled_code }};
 {% endmacro %}
 
 {% macro fabric_atomic_replace_sql(
@@ -142,20 +133,11 @@
     create_sql
 ) %}
   {{ get_use_database_sql(target_relation.database) }}
-  BEGIN TRY
-    BEGIN TRANSACTION;
-    {{ create_sql }}
-    {% if existing_relation is not none %}
-      DROP {{ existing_relation.type }} {{ existing_relation.include(database=False) }};
-    {% endif %}
-    EXEC sp_rename
-      '{{ intermediate_relation.include(database=False) | replace("'", "''") }}',
-      '{{ target_relation.identifier | replace("'", "''") }}';
-    COMMIT TRANSACTION;
-  END TRY
-  BEGIN CATCH
-    IF @@TRANCOUNT > 0
-      ROLLBACK TRANSACTION;
-    THROW;
-  END CATCH;
+  {{ create_sql }}
+  {% if existing_relation is not none %}
+    DROP {{ existing_relation.type }} {{ existing_relation.include(database=False) }};
+  {% endif %}
+  EXEC sp_rename
+    '{{ intermediate_relation.include(database=False) | replace("'", "''") }}',
+    '{{ target_relation.identifier | replace("'", "''") }}';
 {% endmacro %}

--- a/dbt/include/fabric/macros/materializations/models/table/table.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/table.sql
@@ -6,46 +6,16 @@
   {%- set target_relation = this.incorporate(type='table') -%}
   {%- set existing_relation = load_cached_relation(this) -%}
 
-  {# Making an intermediate relation #}
-  {%- set intermediate_relation = make_intermediate_relation(target_relation) -%}
-  {%- set preexisting_intermediate_relation = load_cached_relation(intermediate_relation) -%}
-
-  {%- set backup_relation_type = 'table' if existing_relation is none else existing_relation.type -%}
-  {%- set backup_relation = make_backup_relation(target_relation, backup_relation_type) -%}
-  {%- set preexisting_backup_relation = load_cached_relation(backup_relation) -%}
-  {{ drop_relation_if_exists(preexisting_backup_relation) }}
-
-  {# Drop intermediate relation if it exists before materializing intermediate relation #}
-  {{ drop_relation_if_exists(preexisting_intermediate_relation) }}
-
   {{ run_hooks(pre_hooks, inside_transaction=False) }}
   {# `BEGIN` happens here: #}
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
 
-  {# build model #}
-  {% call statement('main', language=language) -%}
-    {{ create_table_as(False, intermediate_relation, compiled_code, language) }}
-  {% endcall %}
-
-  {% do create_indexes(intermediate_relation) %}
-
-  {% if existing_relation is not none %}
-
-    {# Rename existing relation to back up relation #}
-    {{ adapter.rename_relation(existing_relation, backup_relation) }}
-
-    {# Renaming intermediate relation as main relation #}
-    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-    {# Drop backup relation #}
-    {{ adapter.drop_relation(backup_relation) }}
-
-  {% else %}
-
-    {# Renaming intermediate relation as main relation #}
-    {{ adapter.rename_relation(intermediate_relation, target_relation) }}
-
-  {% endif %}
+  {% set refresh_plan = fabric_full_refresh_table(
+      target_relation,
+      existing_relation,
+      compiled_code,
+      language
+  ) %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 
@@ -57,9 +27,16 @@
   {# `COMMIT` happens here #}
   {{ adapter.commit() }}
 
-  {# Add constraints including FK relation. #}
-  {{ build_model_constraints(target_relation) }}
-  {{ create_or_update_statistics(target_relation) }}
+  {# Add or reconcile constraints including FK relations. #}
+  {% if refresh_plan['action'] == 'reload' %}
+    {{ reconcile_model_constraints(target_relation, refresh_plan) }}
+  {% else %}
+    {{ build_model_constraints(target_relation) }}
+  {% endif %}
+  {{ create_or_update_statistics(
+      target_relation,
+      existing_table=(refresh_plan['action'] == 'reload')
+  ) }}
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/dbt/include/fabric/macros/materializations/models/table/table.sql
+++ b/dbt/include/fabric/macros/materializations/models/table/table.sql
@@ -24,8 +24,6 @@
   {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
 
   {% do persist_docs(target_relation, model) %}
-  {# `COMMIT` happens here #}
-  {{ adapter.commit() }}
 
   {# Add or reconcile constraints including FK relations. #}
   {% if refresh_plan['action'] == 'reload' %}
@@ -37,6 +35,10 @@
       target_relation,
       existing_table=(refresh_plan['action'] == 'reload')
   ) }}
+
+  {# `COMMIT` happens here #}
+  {{ adapter.commit() }}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/dbt/include/fabric/macros/materializations/models/view/view.sql
+++ b/dbt/include/fabric/macros/materializations/models/view/view.sql
@@ -10,11 +10,16 @@
       {%- set backup_relation = make_backup_relation(target_relation, 'view') -%}
   {% endif %}
 
-  {% if (existing_relation != none) %}
-    -- drop the temp relations if they exist already in the database
-    {% do adapter.drop_relation(backup_relation) %}
-    -- Rename target relation as backup relation
-    {{ adapter.rename_relation(existing_relation, backup_relation) }}
+  {% if backup_relation is not none %}
+    {%- set preexisting_backup_relation = adapter.get_relation(
+        database=backup_relation.database,
+        schema=backup_relation.schema,
+        identifier=backup_relation.identifier
+    ) -%}
+    {% if preexisting_backup_relation is not none %}
+      {% do adapter.drop_relation(preexisting_backup_relation) %}
+      {% do adapter.commit() %}
+    {% endif %}
   {% endif %}
 
   {% set grant_config = config.get('grants') %}
@@ -22,6 +27,10 @@
 
   -- `BEGIN` happens here:
   {{ run_hooks(pre_hooks, inside_transaction=True) }}
+
+  {% if existing_relation is not none %}
+    {{ adapter.rename_relation(existing_relation, backup_relation) }}
+  {% endif %}
 
   -- build model
   {% call statement('main') -%}
@@ -33,10 +42,13 @@
 
   {% do persist_docs(target_relation, model) %}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
-  {{ adapter.commit() }}
-  {% if (backup_relation != none) %}
+
+  {% if backup_relation is not none %}
     {% do adapter.drop_relation(backup_relation) %}
   {% endif %}
+
+  {{ adapter.commit() }}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/dbt/include/fabric/macros/materializations/seeds/helpers.sql
+++ b/dbt/include/fabric/macros/materializations/seeds/helpers.sql
@@ -6,6 +6,23 @@
   {{ return(400) }}
 {% endmacro %}
 
+{% macro fabric__reset_csv_table(model, full_refresh, old_relation, agate_table) %}
+    {# reset_csv_table mutates the target before any statement() call can open the transaction. #}
+    {% call statement('begin_seed_reset', auto_begin=True) %}
+        select 1
+    {% endcall %}
+
+    {% if full_refresh %}
+        {{ adapter.drop_relation(old_relation) }}
+        {% set sql = create_csv_table(model, agate_table) %}
+    {% else %}
+        {{ adapter.truncate_relation(old_relation) }}
+        {% set sql = "truncate table " ~ old_relation.render() %}
+    {% endif %}
+
+    {{ return(sql) }}
+{% endmacro %}
+
 {% macro calc_batch_size(num_columns) %}
     {#
         SQL Server allows for a max of 2100 parameters in a single statement.

--- a/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
+++ b/dbt/include/fabric/macros/materializations/snapshots/snapshot.sql
@@ -103,13 +103,15 @@
   {% endif %}
 
   {{ run_hooks(post_hooks, inside_transaction=True) }}
-  {{ adapter.commit() }}
+
+  {{ create_or_update_statistics(target_relation, existing_table=target_relation_exists) }}
 
   {% if staging_table is defined %}
       {% do post_snapshot(staging_table) %}
   {% endif %}
 
-  {{ create_or_update_statistics(target_relation, existing_table=target_relation_exists) }}
+  {{ adapter.commit() }}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ return({'relations': [target_relation]}) }}
 

--- a/dbt/include/fabric/macros/utils/date_spine.sql
+++ b/dbt/include/fabric/macros/utils/date_spine.sql
@@ -1,5 +1,9 @@
 {% macro fabric__get_intervals_between(start_date, end_date, datepart) -%}
-    {%- call statement('get_intervals_between', fetch_result=True) %}
+    {%- call statement(
+        'get_intervals_between',
+        fetch_result=True,
+        auto_begin=False
+    ) %}
 
         select {{ dbt.datediff(start_date, end_date, datepart) }} as diff
 

--- a/dbt/include/fabric/macros/utils/validate_sql.sql
+++ b/dbt/include/fabric/macros/utils/validate_sql.sql
@@ -1,11 +1,11 @@
 {% macro fabric__validate_sql(sql) -%}
-  {% call statement('set_showplan_on') -%}
+  {% call statement('set_showplan_on', auto_begin=False) -%}
     SET SHOWPLAN_XML ON;
   {% endcall %}
-  {% call statement('run_sql') -%}
+  {% call statement('run_sql', auto_begin=False) -%}
     {{ sql }}
   {% endcall %}
-  {% call statement('set_showplan_off') -%}
+  {% call statement('set_showplan_off', auto_begin=False) -%}
     SET SHOWPLAN_XML OFF;
   {% endcall %}
   {{ return(load_result('run_sql')) }}

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,5 +1,30 @@
+import pytest
+
+from dbt.tests.adapter.empty._models import (
+    ephemeral_model_input_sql,
+    model_input_sql,
+    schema_sources_yml,
+)
 from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
+
+model_sql_with_aliases = """
+select *
+from {{ ref('model_input') }} as model_input_alias
+union all
+select *
+from {{ ref('ephemeral_model_input') }} as ephemeral_model_input_alias
+union all
+select *
+from {{ source('seed_sources', 'raw_source') }} as raw_source_alias
+"""
 
 
 class TestEmpty(BaseTestEmpty):
-    pass
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "model_input.sql": model_input_sql,
+            "ephemeral_model_input.sql": ephemeral_model_input_sql,
+            "model.sql": model_sql_with_aliases,
+            "sources.yml": schema_sources_yml,
+        }

--- a/tests/functional/adapter/test_empty.py
+++ b/tests/functional/adapter/test_empty.py
@@ -1,30 +1,5 @@
-import pytest
-
-from dbt.tests.adapter.empty._models import (
-    ephemeral_model_input_sql,
-    model_input_sql,
-    schema_sources_yml,
-)
 from dbt.tests.adapter.empty.test_empty import BaseTestEmpty
-
-model_sql_with_aliases = """
-select *
-from {{ ref('model_input') }} as model_input_alias
-union all
-select *
-from {{ ref('ephemeral_model_input') }} as ephemeral_model_input_alias
-union all
-select *
-from {{ source('seed_sources', 'raw_source') }} as raw_source_alias
-"""
 
 
 class TestEmpty(BaseTestEmpty):
-    @pytest.fixture(scope="class")
-    def models(self):
-        return {
-            "model_input.sql": model_input_sql,
-            "ephemeral_model_input.sql": ephemeral_model_input_sql,
-            "model.sql": model_sql_with_aliases,
-            "sources.yml": schema_sources_yml,
-        }
+    pass

--- a/tests/functional/adapter/test_table_refresh.py
+++ b/tests/functional/adapter/test_table_refresh.py
@@ -1,0 +1,286 @@
+import pytest
+
+from dbt.tests.util import run_dbt, run_dbt_and_capture, write_file
+
+table_model_sql = """
+{{ config(materialized='table') }}
+select cast(1 as int) as id, cast('{{ value }}' as varchar(20)) as value
+"""
+
+incremental_model_sql = """
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge') }}
+select cast(1 as int) as id, cast('{{ value }}' as varchar(20)) as value
+"""
+
+constraint_schema_yml = """
+version: 2
+models:
+  - name: constraint_refresh
+    config:
+      contract:
+        enforced: true
+    constraints:
+      - type: {constraint_type}
+        name: {constraint_name}
+        columns: [{constraint_columns}]
+{expression}
+    columns:
+      - name: id
+        data_type: int
+        constraints:
+          - type: not_null
+      - name: value
+        data_type: varchar(20)
+        constraints:
+          - type: not_null
+"""
+
+
+def _object_id(project, relation_name):
+    result = project.run_sql(
+        f"select object_id('{project.test_schema}.{relation_name}')",
+        fetch="one",
+    )
+    return result[0]
+
+
+def _value(project, relation_name):
+    result = project.run_sql(
+        f"select value from {project.test_schema}.{relation_name} where id = 1",
+        fetch="one",
+    )
+    return result[0]
+
+
+def _constraint_columns(project, relation_name, constraint_name):
+    result = project.run_sql(
+        f"""
+        select c.name
+        from sys.key_constraints kc
+        join sys.index_columns ic
+          on kc.parent_object_id = ic.object_id
+         and kc.unique_index_id = ic.index_id
+        join sys.columns c
+          on ic.object_id = c.object_id
+         and ic.column_id = c.column_id
+        where kc.parent_object_id = object_id(
+          '{project.test_schema}.{relation_name}'
+        )
+          and kc.name = '{constraint_name}'
+        order by ic.key_ordinal
+        """,
+        fetch="all",
+    )
+    return [row[0] for row in result]
+
+
+class TestTableRefreshPreservesObject:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"refresh_table.sql": table_model_sql.replace("{{ value }}", "first")}
+
+    def test_table_reload_preserves_object_id(self, project):
+        run_dbt(["run", "-s", "refresh_table"])
+        original_object_id = _object_id(project, "refresh_table")
+
+        write_file(
+            table_model_sql.replace("{{ value }}", "second"),
+            "models",
+            "refresh_table.sql",
+        )
+        run_dbt(["run", "-s", "refresh_table"])
+
+        assert _object_id(project, "refresh_table") == original_object_id
+        assert _value(project, "refresh_table") == "second"
+
+
+class TestTableRefreshReplacesChangedSchema:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"replace_table.sql": table_model_sql.replace("{{ value }}", "first")}
+
+    def test_schema_change_replaces_object(self, project):
+        run_dbt(["run", "-s", "replace_table"])
+        original_object_id = _object_id(project, "replace_table")
+
+        write_file(
+            """
+            {{ config(materialized='table') }}
+            select cast(1 as bigint) as id, cast('second' as varchar(20)) as value
+            """,
+            "models",
+            "replace_table.sql",
+        )
+        run_dbt(["run", "-s", "replace_table"])
+
+        assert _object_id(project, "replace_table") != original_object_id
+        assert _value(project, "replace_table") == "second"
+
+
+class TestTableRefreshReplacesChangedLayout:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "replace_layout.sql": """
+            {{ config(materialized='table', cluster_by=['id']) }}
+            select cast(1 as int) as id, cast('first' as varchar(20)) as value
+            """
+        }
+
+    def test_cluster_by_change_replaces_object(self, project):
+        run_dbt(["run", "-s", "replace_layout"])
+        original_object_id = _object_id(project, "replace_layout")
+
+        write_file(
+            """
+            {{ config(materialized='table', cluster_by=['value']) }}
+            select cast(1 as int) as id, cast('second' as varchar(20)) as value
+            """,
+            "models",
+            "replace_layout.sql",
+        )
+        run_dbt(["run", "-s", "replace_layout"])
+
+        assert _object_id(project, "replace_layout") != original_object_id
+        assert _value(project, "replace_layout") == "second"
+
+
+class TestTableRefreshReplacesSelfReference:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"self_reference.sql": table_model_sql.replace("{{ value }}", "original")}
+
+    def test_self_reference_replaces_object_before_reading_target(self, project):
+        run_dbt(["run", "-s", "self_reference"])
+        original_object_id = _object_id(project, "self_reference")
+
+        write_file(
+            """
+            {{ config(materialized='table') }}
+            select id, value
+            from {{ this }}
+            """,
+            "models",
+            "self_reference.sql",
+        )
+        run_dbt(["run", "-s", "self_reference"])
+
+        assert _object_id(project, "self_reference") != original_object_id
+        assert _value(project, "self_reference") == "original"
+
+
+class TestIncrementalFullRefreshPreservesObject:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"refresh_incremental.sql": incremental_model_sql.replace("{{ value }}", "first")}
+
+    def test_incremental_full_refresh_preserves_object_id(self, project):
+        run_dbt(["run", "-s", "refresh_incremental"])
+        original_object_id = _object_id(project, "refresh_incremental")
+
+        write_file(
+            incremental_model_sql.replace("{{ value }}", "second"),
+            "models",
+            "refresh_incremental.sql",
+        )
+        run_dbt(["run", "--full-refresh", "-s", "refresh_incremental"])
+
+        assert _object_id(project, "refresh_incremental") == original_object_id
+        assert _value(project, "refresh_incremental") == "second"
+
+
+class TestTableRefreshRollback:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {"rollback_table.sql": table_model_sql.replace("{{ value }}", "original")}
+
+    def test_failed_reload_rolls_back_truncate(self, project):
+        run_dbt(["run", "-s", "rollback_table"])
+        original_object_id = _object_id(project, "rollback_table")
+
+        write_file(
+            """
+            {{ config(materialized='table') }}
+            select cast(1 as int) as id,
+                   cast(case when 1 = 1 then 1 / 0 else 1 end as varchar(20)) as value
+            """,
+            "models",
+            "rollback_table.sql",
+        )
+        run_dbt_and_capture(["run", "-s", "rollback_table"], expect_pass=False)
+
+        assert _object_id(project, "rollback_table") == original_object_id
+        assert _value(project, "rollback_table") == "original"
+
+
+class TestTableConstraintReconciliation:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "constraint_refresh.sql": table_model_sql.replace("{{ value }}", "value"),
+            "schema.yml": constraint_schema_yml.format(
+                constraint_type="unique",
+                constraint_name="uq_constraint_refresh",
+                constraint_columns="id",
+                expression="",
+            ),
+        }
+
+    def test_changed_constraint_is_reconciled_without_replacing_table(self, project):
+        run_dbt(["run", "-s", "constraint_refresh"])
+        original_object_id = _object_id(project, "constraint_refresh")
+        assert _constraint_columns(
+            project,
+            "constraint_refresh",
+            "uq_constraint_refresh",
+        ) == ["id"]
+
+        write_file(
+            constraint_schema_yml.format(
+                constraint_type="unique",
+                constraint_name="uq_constraint_refresh",
+                constraint_columns="value",
+                expression="",
+            ),
+            "models",
+            "schema.yml",
+        )
+        run_dbt(["run", "-s", "constraint_refresh"])
+
+        assert _object_id(project, "constraint_refresh") == original_object_id
+        assert _constraint_columns(
+            project,
+            "constraint_refresh",
+            "uq_constraint_refresh",
+        ) == ["value"]
+
+    def test_failed_constraint_addition_rolls_back_constraint_drop(self, project):
+        write_file(
+            constraint_schema_yml.format(
+                constraint_type="unique",
+                constraint_name="uq_constraint_refresh",
+                constraint_columns="value",
+                expression="",
+            ),
+            "models",
+            "schema.yml",
+        )
+        run_dbt(["run", "-s", "constraint_refresh"])
+
+        write_file(
+            constraint_schema_yml.format(
+                constraint_type="foreign_key",
+                constraint_name="fk_constraint_refresh",
+                constraint_columns="id",
+                expression=(f"        expression: {project.test_schema}.missing_parent (id)"),
+            ),
+            "models",
+            "schema.yml",
+        )
+        run_dbt_and_capture(["run", "-s", "constraint_refresh"], expect_pass=False)
+
+        assert _constraint_columns(
+            project,
+            "constraint_refresh",
+            "uq_constraint_refresh",
+        ) == ["value"]

--- a/tests/functional/adapter/test_table_refresh.py
+++ b/tests/functional/adapter/test_table_refresh.py
@@ -266,6 +266,7 @@ class TestTableConstraintReconciliation:
             "schema.yml",
         )
         run_dbt(["run", "-s", "constraint_refresh"])
+        original_object_id = _object_id(project, "constraint_refresh")
 
         write_file(
             constraint_schema_yml.format(
@@ -277,8 +278,15 @@ class TestTableConstraintReconciliation:
             "models",
             "schema.yml",
         )
+        write_file(
+            table_model_sql.replace("{{ value }}", "replacement"),
+            "models",
+            "constraint_refresh.sql",
+        )
         run_dbt_and_capture(["run", "-s", "constraint_refresh"], expect_pass=False)
 
+        assert _object_id(project, "constraint_refresh") == original_object_id
+        assert _value(project, "constraint_refresh") == "value"
         assert _constraint_columns(
             project,
             "constraint_refresh",

--- a/tests/functional/adapter/test_transactions.py
+++ b/tests/functional/adapter/test_transactions.py
@@ -1,0 +1,714 @@
+import pytest
+
+from dbt.tests.util import patch_microbatch_end_time, run_dbt, write_file
+
+FAIL_HOOK_CONFIG = """
+{% if var('fail_hook', false) %}
+  {{ config(post_hook=["select 1 / 0"]) }}
+{% endif %}
+"""
+
+TABLE_MODEL = (
+    FAIL_HOOK_CONFIG
+    + """
+{{ config(materialized='table') }}
+select cast({{ var('value', 1) }} as int) as id,
+       cast('{{ var("label", "original") }}' as varchar(20)) as label
+"""
+)
+
+INCREMENTAL_MODEL = (
+    FAIL_HOOK_CONFIG
+    + """
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge') }}
+select cast(1 as int) as id,
+       cast('{{ var("label", "original") }}' as varchar(20)) as label
+"""
+)
+
+MULTI_STATEMENT_INCREMENTAL_MODEL = """
+{{ config(
+    materialized='incremental',
+    incremental_strategy='transaction_probe'
+) }}
+select cast(1 as int) as id, cast('original' as varchar(20)) as label
+"""
+
+MULTI_STATEMENT_STRATEGY = """
+{% macro get_incremental_transaction_probe_sql(arg_dict) %}
+  delete from {{ arg_dict['target_relation'] }};
+  select 1 / 0;
+{% endmacro %}
+"""
+
+VIEW_MODEL = (
+    FAIL_HOOK_CONFIG
+    + """
+{{ config(materialized='view') }}
+select cast({{ var('value', 1) }} as int) as id
+"""
+)
+
+FAILING_PRE_HOOK_MODEL = """
+{{ config(
+    materialized='table',
+    pre_hook=["insert into {{ this.schema }}.transaction_audit values ('inside')"]
+) }}
+select 1 / 0 as id
+"""
+
+FAILING_OUTSIDE_PRE_HOOK_MODEL = """
+{{ config(
+    materialized='table',
+    pre_hook=[{
+        "sql": "insert into {{ this.schema }}.transaction_audit values ('outside')",
+        "transaction": false
+    }]
+) }}
+select 1 / 0 as id
+"""
+
+FAILING_OUTSIDE_POST_HOOK_MODEL = """
+{{ config(
+    materialized='table',
+    post_hook=[{"sql": "select 1 / 0", "transaction": false}]
+) }}
+select cast(1 as int) as id
+"""
+
+FAILING_STATISTICS_MODEL = """
+{{ config(
+    materialized='table',
+    grants={'select': ['public']},
+    statistics=['missing_column']
+) }}
+select cast(2 as int) as id, cast('replacement' as varchar(20)) as label
+"""
+
+METADATA_COMMIT_MODEL = """
+{{ config(
+    materialized='table',
+    grants={'select': ['public']},
+    statistics=['id']
+) }}
+select cast(1 as int) as id, cast('committed' as varchar(20)) as label
+"""
+
+SNAPSHOT = """
+{% snapshot transaction_snapshot %}
+{% set hooks = ["select 1 / 0"] if var('fail_hook', false) else [] %}
+{{ config(
+    target_schema=schema,
+    unique_key='id',
+    strategy='timestamp',
+    updated_at='updated_at',
+    post_hook=hooks
+) }}
+select id, value, updated_at
+{% if var('add_snapshot_column', false) %}
+     , cast('new' as varchar(20)) as added_column
+{% endif %}
+from {{ ref('transaction_snapshot_source') }}
+{% endsnapshot %}
+"""
+
+
+def _value(project, relation_name, column="label"):
+    return project.run_sql(
+        f"select {column} from {project.test_schema}.{relation_name} where id = 1",
+        fetch="one",
+    )[0]
+
+
+def _object_id(project, relation_name):
+    return project.run_sql(
+        f"select object_id('{project.test_schema}.{relation_name}')",
+        fetch="one",
+    )[0]
+
+
+def _leftover_relation_count(project, relation_name):
+    return project.run_sql(
+        f"""
+        select count(*)
+        from sys.objects o
+        join sys.schemas s on s.schema_id = o.schema_id
+        where s.name = '{project.test_schema}'
+          and (
+            o.name like '{relation_name}__dbt_%'
+            or o.name = '{relation_name}_snapshot_staging_temp_view'
+          )
+        """,
+        fetch="one",
+    )[0]
+
+
+def _column_names(project, relation_name):
+    return {
+        row[0]
+        for row in project.run_sql(
+            f"""
+            select c.name
+            from sys.columns c
+            where c.object_id = object_id(
+                '{project.test_schema}.{relation_name}'
+            )
+            """,
+            fetch="all",
+        )
+    }
+
+
+class TestMaterializationTransactions:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "transaction_table.sql": TABLE_MODEL,
+            "transaction_replace.sql": TABLE_MODEL,
+            "transaction_recovery.sql": TABLE_MODEL,
+            "transaction_incremental.sql": INCREMENTAL_MODEL,
+            "transaction_schema_change.sql": (
+                FAIL_HOOK_CONFIG
+                + """
+{{ config(
+    materialized='incremental',
+    unique_key='id',
+    incremental_strategy='merge',
+    on_schema_change='sync_all_columns'
+) }}
+select cast(1 as int) as id,
+       cast('{{ var("label", "original") }}' as varchar(20)) as label
+{% if var('add_column', false) %}
+     , cast('new' as varchar(20)) as added_column
+{% endif %}
+"""
+            ),
+            "multi_statement_incremental.sql": MULTI_STATEMENT_INCREMENTAL_MODEL,
+            "transaction_view.sql": VIEW_MODEL,
+            "transaction_type_swap.sql": TABLE_MODEL,
+            "failing_inside_pre_hook.sql": FAILING_PRE_HOOK_MODEL,
+            "failing_outside_pre_hook.sql": FAILING_OUTSIDE_PRE_HOOK_MODEL,
+            "failing_outside_post_hook.sql": FAILING_OUTSIDE_POST_HOOK_MODEL,
+            "statistics_rollback.sql": TABLE_MODEL,
+            "metadata_commit.sql": METADATA_COMMIT_MODEL,
+        }
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {"transaction_probe.sql": MULTI_STATEMENT_STRATEGY}
+
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "transaction_snapshot_source.csv": (
+                "id,value,updated_at\n1,original,2024-01-01 00:00:00\n"
+            )
+        }
+
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        return {"transaction_snapshot.sql": SNAPSHOT}
+
+    def test_failed_table_reload_restores_data_and_cleans_temporary_relations(self, project):
+        run_dbt(["run", "-s", "transaction_table"])
+        original_object_id = _object_id(project, "transaction_table")
+
+        run_dbt(
+            [
+                "run",
+                "-s",
+                "transaction_table",
+                "--vars",
+                "{fail_hook: true, value: 2, label: replacement}",
+            ],
+            expect_pass=False,
+        )
+
+        assert _object_id(project, "transaction_table") == original_object_id
+        assert _value(project, "transaction_table") == "original"
+        assert _leftover_relation_count(project, "transaction_table") == 0
+
+    def test_failed_table_replacement_restores_original_table(self, project):
+        run_dbt(["run", "-s", "transaction_replace"])
+        original_object_id = _object_id(project, "transaction_replace")
+
+        write_file(
+            FAIL_HOOK_CONFIG
+            + """
+            {{ config(materialized='table') }}
+            select cast(2 as bigint) as id,
+                   cast('replacement' as varchar(40)) as label,
+                   cast('new' as varchar(10)) as added_column
+            """,
+            "models",
+            "transaction_replace.sql",
+        )
+
+        run_dbt(
+            ["run", "-s", "transaction_replace", "--vars", "{fail_hook: true}"],
+            expect_pass=False,
+        )
+
+        assert _object_id(project, "transaction_replace") == original_object_id
+        assert _value(project, "transaction_replace") == "original"
+        assert _leftover_relation_count(project, "transaction_replace") == 0
+
+    def test_failed_incremental_merge_restores_target(self, project):
+        run_dbt(["run", "-s", "transaction_incremental"])
+
+        run_dbt(
+            [
+                "run",
+                "-s",
+                "transaction_incremental",
+                "--vars",
+                "{fail_hook: true, label: replacement}",
+            ],
+            expect_pass=False,
+        )
+
+        assert _value(project, "transaction_incremental") == "original"
+        assert _leftover_relation_count(project, "transaction_incremental") == 0
+
+    def test_failed_incremental_schema_change_restores_schema_and_data(self, project):
+        run_dbt(["run", "-s", "transaction_schema_change"])
+
+        run_dbt(
+            [
+                "run",
+                "-s",
+                "transaction_schema_change",
+                "--vars",
+                "{fail_hook: true, add_column: true, label: replacement}",
+            ],
+            expect_pass=False,
+        )
+
+        assert _value(project, "transaction_schema_change") == "original"
+        assert _column_names(project, "transaction_schema_change") == {"id", "label"}
+        assert _leftover_relation_count(project, "transaction_schema_change") == 0
+
+    def test_multi_statement_incremental_failure_rolls_back_earlier_delete(self, project):
+        run_dbt(["run", "-s", "multi_statement_incremental"])
+
+        run_dbt(["run", "-s", "multi_statement_incremental"], expect_pass=False)
+
+        assert _value(project, "multi_statement_incremental") == "original"
+        assert _leftover_relation_count(project, "multi_statement_incremental") == 0
+
+    def test_failed_view_replacement_restores_original_view(self, project):
+        run_dbt(["run", "-s", "transaction_view"])
+
+        run_dbt(
+            ["run", "-s", "transaction_view", "--vars", "{fail_hook: true, value: 2}"],
+            expect_pass=False,
+        )
+
+        assert _value(project, "transaction_view", column="id") == 1
+        assert _leftover_relation_count(project, "transaction_view") == 0
+
+    def test_failed_table_to_view_swap_restores_original_table(self, project):
+        run_dbt(["run", "-s", "transaction_type_swap"])
+        original_object_id = _object_id(project, "transaction_type_swap")
+
+        write_file(
+            VIEW_MODEL,
+            "models",
+            "transaction_type_swap.sql",
+        )
+        run_dbt(
+            [
+                "run",
+                "-s",
+                "transaction_type_swap",
+                "--vars",
+                "{fail_hook: true, value: 2}",
+            ],
+            expect_pass=False,
+        )
+
+        assert _object_id(project, "transaction_type_swap") == original_object_id
+        assert _value(project, "transaction_type_swap") == "original"
+        assert _leftover_relation_count(project, "transaction_type_swap") == 0
+
+    def test_transactional_pre_hook_rolls_back_with_model(self, project):
+        project.run_sql(
+            "drop table if exists {schema}.transaction_audit; "
+            "create table {schema}.transaction_audit (location varchar(20));"
+        )
+
+        run_dbt(["run", "-s", "failing_inside_pre_hook"], expect_pass=False)
+
+        assert (
+            project.run_sql("select count(*) from {schema}.transaction_audit", fetch="one")[0] == 0
+        )
+
+    def test_outside_pre_hook_commits_before_model_transaction(self, project):
+        project.run_sql(
+            "drop table if exists {schema}.transaction_audit; "
+            "create table {schema}.transaction_audit (location varchar(20));"
+        )
+
+        run_dbt(["run", "-s", "failing_outside_pre_hook"], expect_pass=False)
+
+        assert (
+            project.run_sql(
+                "select count(*) from {schema}.transaction_audit where location = 'outside'",
+                fetch="one",
+            )[0]
+            == 1
+        )
+
+    def test_outside_post_hook_failure_does_not_rollback_committed_model(self, project):
+        run_dbt(["run", "-s", "failing_outside_post_hook"], expect_pass=False)
+
+        assert _value(project, "failing_outside_post_hook", column="id") == 1
+
+    def test_failed_statistics_rolls_back_data_grants_and_schema(self, project):
+        run_dbt(["run", "-s", "statistics_rollback"])
+        original_object_id = _object_id(project, "statistics_rollback")
+
+        write_file(
+            FAILING_STATISTICS_MODEL,
+            "models",
+            "statistics_rollback.sql",
+        )
+        run_dbt(["run", "-s", "statistics_rollback"], expect_pass=False)
+
+        assert _object_id(project, "statistics_rollback") == original_object_id
+        assert _value(project, "statistics_rollback") == "original"
+        grant_count = project.run_sql(
+            f"""
+            select count(*)
+            from sys.database_permissions p
+            join sys.database_principals r
+              on r.principal_id = p.grantee_principal_id
+            where p.major_id = object_id(
+                '{project.test_schema}.statistics_rollback'
+            )
+              and r.name = 'public'
+              and p.permission_name = 'SELECT'
+            """,
+            fetch="one",
+        )[0]
+        assert grant_count == 0
+
+    def test_grants_and_statistics_commit_with_model(self, project):
+        run_dbt(["run", "-s", "metadata_commit"])
+
+        grant_count = project.run_sql(
+            f"""
+            select count(*)
+            from sys.database_permissions p
+            join sys.database_principals r
+              on r.principal_id = p.grantee_principal_id
+            where p.major_id = object_id(
+                '{project.test_schema}.metadata_commit'
+            )
+              and r.name = 'public'
+              and p.permission_name = 'SELECT'
+            """,
+            fetch="one",
+        )[0]
+        statistics_count = project.run_sql(
+            f"""
+            select count(*)
+            from sys.stats
+            where object_id = object_id(
+                '{project.test_schema}.metadata_commit'
+            )
+              and user_created = 1
+            """,
+            fetch="one",
+        )[0]
+
+        assert grant_count == 1
+        assert statistics_count == 1
+
+    def test_failed_snapshot_merge_restores_snapshot(self, project):
+        run_dbt(["seed", "-s", "transaction_snapshot_source"])
+        run_dbt(["snapshot", "-s", "transaction_snapshot"])
+
+        project.run_sql(
+            "update {schema}.transaction_snapshot_source "
+            "set value = 'replacement', "
+            "updated_at = cast('2024-02-01 00:00:00' as datetime2)"
+        )
+        run_dbt(
+            ["snapshot", "-s", "transaction_snapshot", "--vars", "{fail_hook: true}"],
+            expect_pass=False,
+        )
+
+        rows = project.run_sql(
+            "select value, dbt_valid_to "
+            "from {schema}.transaction_snapshot "
+            "order by dbt_valid_from",
+            fetch="all",
+        )
+        assert len(rows) == 1
+        assert rows[0][0] == "original"
+        assert rows[0][1] is None
+        assert _leftover_relation_count(project, "transaction_snapshot") == 0
+
+    def test_failed_snapshot_schema_change_restores_snapshot_schema(self, project):
+        run_dbt(["seed", "-s", "transaction_snapshot_source"])
+        run_dbt(["snapshot", "-s", "transaction_snapshot"])
+
+        project.run_sql(
+            "update {schema}.transaction_snapshot_source "
+            "set value = 'replacement', "
+            "updated_at = cast('2024-03-01 00:00:00' as datetime2)"
+        )
+        run_dbt(
+            [
+                "snapshot",
+                "-s",
+                "transaction_snapshot",
+                "--vars",
+                "{fail_hook: true, add_snapshot_column: true}",
+            ],
+            expect_pass=False,
+        )
+
+        assert "added_column" not in _column_names(project, "transaction_snapshot")
+        rows = project.run_sql(
+            "select value, dbt_valid_to "
+            "from {schema}.transaction_snapshot "
+            "order by dbt_valid_from",
+            fetch="all",
+        )
+        assert len(rows) == 1
+        assert rows[0][0] == "original"
+        assert rows[0][1] is None
+        assert _leftover_relation_count(project, "transaction_snapshot") == 0
+
+    def test_failed_run_does_not_poison_next_connection(self, project):
+        run_dbt(["run", "-s", "failing_inside_pre_hook"], expect_pass=False)
+
+        results = run_dbt(["run", "-s", "transaction_recovery"])
+
+        assert len(results) == 1
+        assert _value(project, "transaction_recovery") == "original"
+
+
+class TestSeedTransactionRollback:
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {"failing_transaction_seed.csv": "id,label\n1,original\n"}
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "seeds": {
+                "test": {
+                    "failing_transaction_seed": {
+                        "+post-hook": ["select 1 / {{ var('seed_divisor', 0) }}"],
+                    }
+                }
+            }
+        }
+
+    def test_seed_post_hook_failure_rolls_back_table_creation(self, project):
+        run_dbt(["seed", "-s", "failing_transaction_seed"], expect_pass=False)
+
+        assert _object_id(project, "failing_transaction_seed") is None
+
+    def test_seed_full_refresh_failure_restores_existing_table(self, project):
+        run_dbt(
+            [
+                "seed",
+                "-s",
+                "failing_transaction_seed",
+                "--vars",
+                "{seed_divisor: 1}",
+            ]
+        )
+        original_object_id = _object_id(project, "failing_transaction_seed")
+
+        write_file(
+            "id,label\n1,replacement\n2,new\n",
+            "seeds",
+            "failing_transaction_seed.csv",
+        )
+        run_dbt(
+            ["seed", "-s", "failing_transaction_seed", "--full-refresh"],
+            expect_pass=False,
+        )
+
+        assert _object_id(project, "failing_transaction_seed") == original_object_id
+        assert _value(project, "failing_transaction_seed") == "original"
+
+    def test_seed_truncate_failure_restores_existing_rows(self, project):
+        write_file(
+            "id,label\n1,original\n",
+            "seeds",
+            "failing_transaction_seed.csv",
+        )
+        run_dbt(
+            [
+                "seed",
+                "-s",
+                "failing_transaction_seed",
+                "--vars",
+                "{seed_divisor: 1}",
+            ]
+        )
+
+        write_file(
+            "id,label\n1,replacement\n2,new\n",
+            "seeds",
+            "failing_transaction_seed.csv",
+        )
+        run_dbt(
+            ["seed", "-s", "failing_transaction_seed"],
+            expect_pass=False,
+        )
+
+        assert _value(project, "failing_transaction_seed") == "original"
+        assert (
+            project.run_sql(
+                "select count(*) from {schema}.failing_transaction_seed",
+                fetch="one",
+            )[0]
+            == 1
+        )
+
+
+class TestMicrobatchTransactionRollback:
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "transaction_microbatch_input.sql": """
+{{ config(materialized='table', event_time='event_time') }}
+select 1 as id, cast('2020-01-01' as datetime2(6)) as event_time,
+       cast('original' as varchar(20)) as label
+union all
+select 2 as id, cast('2020-01-02' as datetime2(6)) as event_time,
+       cast('original' as varchar(20)) as label
+union all
+select 3 as id, cast('2020-01-03' as datetime2(6)) as event_time,
+       cast('original' as varchar(20)) as label
+""",
+            "transaction_microbatch.sql": """
+{% set hooks = ["select 1 / 0"] if var('fail_hook', false) else [] %}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='microbatch',
+    event_time='event_time',
+    batch_size='day',
+    begin='2020-01-01 00:00:00.000000',
+    lookback=1,
+    post_hook=hooks
+) }}
+select * from {{ ref('transaction_microbatch_input') }}
+""",
+        }
+
+    def test_failed_batch_restores_rows_deleted_for_reprocessing(self, project):
+        with patch_microbatch_end_time("2020-01-03 13:57:00"):
+            run_dbt(["run"])
+
+        project.run_sql(
+            "update {schema}.transaction_microbatch_input set label = 'replacement' where id = 3"
+        )
+        with patch_microbatch_end_time("2020-01-03 14:57:00"):
+            run_dbt(
+                [
+                    "run",
+                    "-s",
+                    "transaction_microbatch",
+                    "--vars",
+                    "{fail_hook: true}",
+                ],
+                expect_pass=False,
+            )
+
+        assert (
+            project.run_sql(
+                "select label from {schema}.transaction_microbatch where id = 3",
+                fetch="one",
+            )[0]
+            == "original"
+        )
+
+
+class TestFunctionTransactionRollback:
+    @pytest.fixture(scope="class")
+    def functions(self):
+        return {
+            "failing_transaction_function.sql": "SELECT @price * 2",
+            "failing_transaction_function.yml": """
+functions:
+  - name: failing_transaction_function
+    config:
+      post-hook:
+        - "select 1 / {{ var('function_divisor', 0) }}"
+    arguments:
+      - name: price
+        data_type: float
+    returns:
+      data_type: float
+""",
+        }
+
+    def test_function_post_hook_failure_rolls_back_creation(self, project):
+        run_dbt(["build", "-s", "failing_transaction_function"], expect_pass=False)
+
+        assert _object_id(project, "failing_transaction_function") is None
+
+    def test_function_post_hook_failure_restores_previous_definition(self, project):
+        run_dbt(
+            [
+                "build",
+                "-s",
+                "failing_transaction_function",
+                "--vars",
+                "{function_divisor: 1}",
+            ]
+        )
+
+        write_file(
+            "SELECT @price * 3",
+            "functions",
+            "failing_transaction_function.sql",
+        )
+        run_dbt(
+            ["build", "-s", "failing_transaction_function"],
+            expect_pass=False,
+        )
+
+        result = project.run_sql(
+            f"select {project.test_schema}.failing_transaction_function(cast(5 as float))",
+            fetch="one",
+        )
+        assert result[0] == 10
+
+
+class TestParallelMaterializationTransactions:
+    @pytest.fixture(scope="class")
+    def dbt_profile_target_update(self):
+        return {"threads": 4}
+
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            f"parallel_transaction_{model_number}.sql": f"""
+{{{{ config(materialized='table') }}}}
+select cast({model_number} as int) as id
+"""
+            for model_number in range(1, 9)
+        }
+
+    def test_independent_materializations_commit_concurrently(self, project):
+        results = run_dbt(["run"])
+
+        assert len(results) == 8
+        assert all(result.status == "success" for result in results)
+        for model_number in range(1, 9):
+            assert (
+                project.run_sql(
+                    f"select id from {project.test_schema}.parallel_transaction_{model_number}",
+                    fetch="one",
+                )[0]
+                == model_number
+            )

--- a/tests/unit/adapters/fabric/test_fabric_adapter.py
+++ b/tests/unit/adapters/fabric/test_fabric_adapter.py
@@ -8,6 +8,9 @@ from dbt_common.contracts.constraints import (
 )
 
 from dbt.adapters.fabric.fabric_adapter import FabricAdapter
+from dbt.adapters.fabric.fabric_column import FabricColumn
+from dbt.adapters.fabric.fabric_relation import FabricRelation
+from dbt.adapters.fabric.table_refresh import FabricTableConstraint
 
 
 class TestConvertBooleanType:
@@ -77,6 +80,287 @@ class TestDateFunction:
 
 def _make_adapter_instance():
     return object.__new__(FabricAdapter)
+
+
+class TestTableRefreshConstraintPlanning:
+    @pytest.fixture
+    def adapter(self):
+        adapter = _make_adapter_instance()
+        columns = [
+            FabricColumn(
+                "id",
+                "int",
+                char_size=4,
+                numeric_precision=10,
+                numeric_scale=0,
+                is_nullable=False,
+            )
+        ]
+        adapter._describe_query_columns = lambda sql: columns
+        adapter.get_columns_in_relation = lambda relation: columns
+        adapter._get_table_cluster_by = lambda relation: []
+        adapter.get_constraints_in_relation = lambda relation: []
+        return adapter
+
+    @pytest.fixture
+    def relation(self):
+        return FabricRelation.create(
+            database="warehouse",
+            schema="dbo",
+            identifier="refresh_table",
+            type="table",
+        )
+
+    def test_plan_contains_rendered_constraint_addition(self, adapter, relation):
+        plan = adapter.get_table_refresh_plan(
+            relation,
+            "select cast(1 as int) as id",
+            constraints=[
+                {
+                    "name": "uq_refresh_table",
+                    "type": "unique",
+                    "columns": ["id"],
+                }
+            ],
+        )
+
+        assert plan["action"] == "reload"
+        assert plan["constraints_to_add"] == ["uq_refresh_table"]
+        assert plan["constraint_add_sql"] == [
+            "add constraint uq_refresh_table unique nonclustered(id) not enforced"
+        ]
+
+    def test_custom_constraint_forces_replacement(self, adapter, relation):
+        plan = adapter.get_table_refresh_plan(
+            relation,
+            "select cast(1 as int) as id",
+            constraints=[
+                {
+                    "name": "custom_refresh_table",
+                    "type": "custom",
+                    "expression": "constraint custom_refresh_table unique (id)",
+                }
+            ],
+        )
+
+        assert plan["action"] == "replace"
+        assert plan["reason"] == "constraint definition requires table replacement"
+
+    def test_changed_qualified_foreign_key_is_reconciled(self, adapter, relation):
+        adapter.get_constraints_in_relation = lambda relation: [
+            FabricTableConstraint(
+                "fk_refresh_table",
+                "foreign_key",
+                ("id",),
+                referenced_database="warehouse",
+                referenced_schema="archive",
+                referenced_table="parent",
+                referenced_columns=("id",),
+            )
+        ]
+
+        plan = adapter.get_table_refresh_plan(
+            relation,
+            "select cast(1 as int) as id",
+            constraints=[
+                {
+                    "name": "fk_refresh_table",
+                    "type": "foreign_key",
+                    "columns": ["id"],
+                    "expression": "[warehouse].[dbo].[parent] ([id])",
+                }
+            ],
+        )
+
+        assert plan["constraints_to_drop"] == ["fk_refresh_table"]
+        assert plan["constraints_to_add"] == ["fk_refresh_table"]
+
+    def test_unchanged_constraint_is_not_rendered(self, adapter, relation):
+        adapter.get_constraints_in_relation = lambda relation: [
+            FabricTableConstraint("uq_refresh_table", "unique", ("id",))
+        ]
+
+        plan = adapter.get_table_refresh_plan(
+            relation,
+            "select cast(1 as int) as id",
+            constraints=[
+                {
+                    "name": "uq_refresh_table",
+                    "type": "unique",
+                    "columns": ["id"],
+                }
+            ],
+        )
+
+        assert plan["action"] == "reload"
+        assert plan["constraints_to_drop"] == []
+        assert plan["constraints_to_add"] == []
+        assert plan["constraint_add_sql"] == []
+
+    def test_query_referencing_target_forces_replacement(self, adapter, relation):
+        plan = adapter.get_table_refresh_plan(
+            relation,
+            "select id from [warehouse].[dbo].[refresh_table]",
+        )
+
+        assert plan["action"] == "replace"
+        assert plan["reason"] == "query references the target relation"
+
+
+class TestTableRefreshMetadata:
+    @pytest.mark.parametrize(
+        ("data_type", "max_length", "expected"),
+        [
+            ("varchar", 100, 100),
+            ("nvarchar", 100, 50),
+            ("NCHAR", "20", 10),
+            ("nvarchar", -1, -1),
+            ("date", None, None),
+        ],
+    )
+    def test_column_character_size(self, data_type, max_length, expected):
+        assert FabricAdapter._column_character_size(data_type, max_length) == expected
+
+    def test_column_character_size_rejects_unexpected_value(self):
+        with pytest.raises(TypeError, match="Unexpected max_length"):
+            FabricAdapter._column_character_size("varchar", object())
+
+    def test_describe_query_columns_maps_metadata_and_skips_hidden_columns(self):
+        adapter = _make_adapter_instance()
+        captured_sql = []
+        adapter._fetch_dicts = lambda sql: (
+            captured_sql.append(sql)
+            or [
+                {
+                    "name": "name",
+                    "system_type_name": "nvarchar(50)",
+                    "max_length": 100,
+                    "precision": 0,
+                    "scale": 0,
+                    "is_nullable": 1,
+                    "collation_name": "Latin1_General_100_CI_AS",
+                    "is_identity_column": 0,
+                    "is_hidden": 0,
+                },
+                {
+                    "name": "hidden",
+                    "system_type_name": "int",
+                    "max_length": 4,
+                    "precision": 10,
+                    "scale": 0,
+                    "is_nullable": 0,
+                    "collation_name": None,
+                    "is_identity_column": 0,
+                    "is_hidden": 1,
+                },
+            ]
+        )
+
+        columns = adapter._describe_query_columns("select 'value' as name")
+
+        assert "select ''value'' as name" in captured_sql[0]
+        assert columns == [
+            FabricColumn(
+                "name",
+                "nvarchar",
+                char_size=50,
+                numeric_precision=0,
+                numeric_scale=0,
+                is_nullable=True,
+                collation_name="Latin1_General_100_CI_AS",
+            )
+        ]
+
+    def test_get_constraints_groups_composite_key_and_foreign_key_columns(self):
+        adapter = _make_adapter_instance()
+        adapter._fetch_dicts = lambda sql: [
+            {
+                "name": "pk_model",
+                "constraint_type": "primary_key",
+                "column_name": "tenant_id",
+                "referenced_database": None,
+                "referenced_schema": None,
+                "referenced_table": None,
+                "referenced_column": None,
+            },
+            {
+                "name": "pk_model",
+                "constraint_type": "primary_key",
+                "column_name": "id",
+                "referenced_database": None,
+                "referenced_schema": None,
+                "referenced_table": None,
+                "referenced_column": None,
+            },
+            {
+                "name": "fk_parent",
+                "constraint_type": "foreign_key",
+                "column_name": "parent_tenant_id",
+                "referenced_database": "warehouse",
+                "referenced_schema": "dbo",
+                "referenced_table": "parent",
+                "referenced_column": "tenant_id",
+            },
+            {
+                "name": "fk_parent",
+                "constraint_type": "foreign_key",
+                "column_name": "parent_id",
+                "referenced_database": "warehouse",
+                "referenced_schema": "dbo",
+                "referenced_table": "parent",
+                "referenced_column": "id",
+            },
+        ]
+        relation = FabricRelation.create(
+            database="warehouse",
+            schema="dbo",
+            identifier="model",
+            type="table",
+        )
+
+        assert adapter.get_constraints_in_relation(relation) == [
+            FabricTableConstraint("pk_model", "primary_key", ("tenant_id", "id")),
+            FabricTableConstraint(
+                "fk_parent",
+                "foreign_key",
+                ("parent_tenant_id", "parent_id"),
+                referenced_database="warehouse",
+                referenced_schema="dbo",
+                referenced_table="parent",
+                referenced_columns=("tenant_id", "id"),
+            ),
+        ]
+
+
+class TestColumnSchemaFromQuery:
+    def test_preserves_connection_type_normalization(self):
+        adapter = _make_adapter_instance()
+        cursor = type(
+            "Cursor",
+            (),
+            {
+                "description": [
+                    ("amount", 3, None, None, None, None, None),
+                    ("id", 4, None, None, None, None, None),
+                ]
+            },
+        )()
+        adapter.connections = type(
+            "Connections",
+            (),
+            {
+                "add_select_query": lambda self, sql: (None, cursor),
+                "data_type_code_to_name": lambda self, code: {
+                    3: "decimal",
+                    4: "int",
+                }[code],
+            },
+        )()
+
+        assert adapter.get_column_schema_from_query("select 1.0 as amount, 1 as id") == [
+            FabricColumn("amount", "decimal"),
+            FabricColumn("id", "int"),
+        ]
 
 
 class TestTimestampAddSql:

--- a/tests/unit/adapters/fabric/test_fabric_column.py
+++ b/tests/unit/adapters/fabric/test_fabric_column.py
@@ -125,3 +125,39 @@ class TestFabricColumnDataType:
     def test_non_datetime2_delegates_to_super(self):
         col = FabricColumn(column="name", dtype="varchar", char_size=100)
         assert col.data_type == "varchar(100)"
+
+
+class TestFabricColumnMetadata:
+    def test_metadata_defaults_preserve_existing_constructor(self):
+        col = FabricColumn("id", "int")
+
+        assert col.is_nullable is None
+        assert col.collation_name is None
+        assert col.is_identity is False
+
+    def test_accepts_catalog_metadata_after_existing_fields(self):
+        col = FabricColumn(
+            "id",
+            "bigint",
+            None,
+            19,
+            0,
+            False,
+            "Latin1_General_100_CI_AS",
+            True,
+        )
+
+        assert col.is_nullable is False
+        assert col.collation_name == "Latin1_General_100_CI_AS"
+        assert col.is_identity is True
+
+    def test_metadata_does_not_change_existing_equality_contract(self):
+        existing = FabricColumn("id", "int")
+        enriched = FabricColumn(
+            "id",
+            "int",
+            is_nullable=False,
+            is_identity=True,
+        )
+
+        assert existing == enriched

--- a/tests/unit/adapters/fabric/test_fabric_connection_manager.py
+++ b/tests/unit/adapters/fabric/test_fabric_connection_manager.py
@@ -1,9 +1,11 @@
 import datetime as dt
+import inspect
 import struct
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
+from dbt_common.exceptions import DbtInternalError
 
 from dbt.adapters.contracts.connection import ConnectionState
 from dbt.adapters.fabric.fabric_connection_manager import (
@@ -12,6 +14,7 @@ from dbt.adapters.fabric.fabric_connection_manager import (
     byte_array_to_datetime,
 )
 from dbt.adapters.fabric.fabric_credentials import FabricCredentials
+from dbt.adapters.sql.connections import SQLConnectionManager
 
 
 class TestBoolToConnectionStringArg:
@@ -132,6 +135,156 @@ class TestServicePrincipalConnectionString:
         assert "PWD={client-secret}" in connection_string
         assert "Authority Id" not in connection_string
         assert "tenant-id" not in connection_string
+
+
+class TestTransactionManagement:
+    def test_execute_does_not_auto_begin_by_default(self):
+        assert (
+            inspect.signature(FabricConnectionManager.execute).parameters["auto_begin"].default
+            is False
+        )
+
+    def test_begin_and_commit_update_connection_state(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(name="transaction-test", transaction_open=False)
+
+        with (
+            mock.patch.object(manager, "get_thread_connection", return_value=connection),
+            mock.patch.object(manager, "add_begin_query") as add_begin,
+            mock.patch.object(manager, "add_commit_query") as add_commit,
+        ):
+            assert manager.begin() is connection
+            assert connection.transaction_open is True
+            add_begin.assert_called_once_with()
+
+            assert manager.commit() is connection
+            assert connection.transaction_open is False
+            add_commit.assert_called_once_with()
+
+    def test_begin_rejects_nested_transaction(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(name="transaction-test", transaction_open=True)
+
+        with mock.patch.object(manager, "get_thread_connection", return_value=connection):
+            with pytest.raises(DbtInternalError, match="already had one open"):
+                manager.begin()
+
+    def test_begin_failure_leaves_transaction_closed(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(name="transaction-test", transaction_open=False)
+
+        with (
+            mock.patch.object(manager, "get_thread_connection", return_value=connection),
+            mock.patch.object(
+                manager, "add_begin_query", side_effect=RuntimeError("begin failed")
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="begin failed"):
+                manager.begin()
+
+        assert connection.transaction_open is False
+
+    def test_commit_requires_open_transaction(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(name="transaction-test", transaction_open=False)
+
+        with mock.patch.object(manager, "get_thread_connection", return_value=connection):
+            with pytest.raises(DbtInternalError, match="does not have one open"):
+                manager.commit()
+
+    def test_commit_failure_leaves_transaction_open_for_rollback(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(name="transaction-test", transaction_open=True)
+
+        with (
+            mock.patch.object(manager, "get_thread_connection", return_value=connection),
+            mock.patch.object(
+                manager, "add_commit_query", side_effect=RuntimeError("commit failed")
+            ),
+        ):
+            with pytest.raises(RuntimeError, match="commit failed"):
+                manager.commit()
+
+        assert connection.transaction_open is True
+
+    def test_transaction_control_uses_guarded_tsql(self):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+
+        with mock.patch.object(
+            manager,
+            "add_query",
+            return_value=(mock.sentinel.connection, mock.sentinel.cursor),
+        ) as add_query:
+            manager.add_begin_query()
+            manager.add_commit_query()
+
+        assert add_query.call_args_list == [
+            mock.call("BEGIN TRANSACTION", auto_begin=False),
+            mock.call("IF @@TRANCOUNT > 0 COMMIT TRANSACTION", auto_begin=False),
+        ]
+
+    def test_rollback_executes_tsql_and_updates_connection_state(self):
+        cursor = mock.MagicMock()
+        handle = mock.MagicMock()
+        handle.cursor.return_value = cursor
+        connection = SimpleNamespace(
+            type="fabric",
+            name="transaction-test",
+            state=ConnectionState.OPEN,
+            transaction_open=True,
+            handle=handle,
+        )
+
+        FabricConnectionManager._rollback(connection)
+
+        cursor.execute.assert_called_once_with("IF @@TRANCOUNT > 0 ROLLBACK TRANSACTION")
+        cursor.close.assert_called_once_with()
+        assert connection.transaction_open is False
+
+    def test_rollback_driver_failure_still_clears_dbt_transaction_state(self):
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = RuntimeError("rollback failed")
+        handle = mock.MagicMock()
+        handle.cursor.return_value = cursor
+        connection = SimpleNamespace(
+            type="fabric",
+            name="transaction-test",
+            state=ConnectionState.OPEN,
+            transaction_open=True,
+            handle=handle,
+        )
+
+        FabricConnectionManager._rollback(connection)
+
+        cursor.close.assert_called_once_with()
+        assert connection.transaction_open is False
+
+    @pytest.mark.parametrize(
+        ("transaction_open", "auto_begin", "expected_retry_limit"),
+        [
+            (False, False, 3),
+            (False, True, 1),
+            (True, False, 1),
+            (True, True, 1),
+        ],
+    )
+    def test_transactional_statements_are_not_retried(
+        self, transaction_open, auto_begin, expected_retry_limit
+    ):
+        manager = FabricConnectionManager.__new__(FabricConnectionManager)
+        connection = SimpleNamespace(transaction_open=transaction_open)
+
+        with (
+            mock.patch.object(manager, "get_thread_connection", return_value=connection),
+            mock.patch.object(
+                SQLConnectionManager,
+                "add_query",
+                return_value=(connection, mock.sentinel.cursor),
+            ) as add_query,
+        ):
+            manager.add_query("select 1", auto_begin=auto_begin, retry_limit=3)
+
+        assert add_query.call_args.args[-1] == expected_retry_limit
 
 
 class MockCursor:

--- a/tests/unit/adapters/fabric/test_fabric_connection_manager.py
+++ b/tests/unit/adapters/fabric/test_fabric_connection_manager.py
@@ -1,13 +1,17 @@
 import datetime as dt
 import struct
+from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
+from dbt.adapters.contracts.connection import ConnectionState
 from dbt.adapters.fabric.fabric_connection_manager import (
     FabricConnectionManager,
     bool_to_connection_string_arg,
     byte_array_to_datetime,
 )
+from dbt.adapters.fabric.fabric_credentials import FabricCredentials
 
 
 class TestBoolToConnectionStringArg:
@@ -78,6 +82,56 @@ class TestDataTypeCodeToName:
     def test_unknown_type_raises(self):
         with pytest.raises(KeyError):
             FabricConnectionManager.data_type_code_to_name("<class 'unknown'>")
+
+
+class TestServicePrincipalConnectionString:
+    def test_uses_mssql_python_supported_keywords(self):
+        credentials = FabricCredentials(
+            database="warehouse",
+            schema="dbo",
+            host="server.datawarehouse.fabric.microsoft.com",
+            authentication="ActiveDirectoryServicePrincipal",
+            tenant_id="tenant-id",
+            client_id="client-id",
+            client_secret="client-secret",
+            lock_timeout=0,
+        )
+        connection = SimpleNamespace(
+            state=ConnectionState.INIT,
+            credentials=credentials,
+            handle=None,
+        )
+        handle = mock.MagicMock()
+        token_provider = mock.MagicMock()
+        token_provider.get_sql_attrs_before.return_value = None
+
+        def retry_connection(connection, connect, **kwargs):
+            connection.handle = connect()
+            connection.state = ConnectionState.OPEN
+            return connection
+
+        FabricConnectionManager._host = None
+        with (
+            mock.patch("mssql_python.connect", return_value=handle) as connect,
+            mock.patch.object(
+                FabricConnectionManager,
+                "get_fabric_token_provider",
+                return_value=token_provider,
+            ),
+            mock.patch.object(
+                FabricConnectionManager,
+                "retry_connection",
+                side_effect=retry_connection,
+            ),
+        ):
+            FabricConnectionManager.open(connection)
+
+        connection_string = connect.call_args.args[0]
+        assert "Authentication=ActiveDirectoryServicePrincipal" in connection_string
+        assert "UID={client-id}" in connection_string
+        assert "PWD={client-secret}" in connection_string
+        assert "Authority Id" not in connection_string
+        assert "tenant-id" not in connection_string
 
 
 class MockCursor:

--- a/tests/unit/adapters/fabric/test_fabric_relation.py
+++ b/tests/unit/adapters/fabric/test_fabric_relation.py
@@ -49,7 +49,10 @@ class TestFabricRelationRenderLimited:
             type=FabricRelationType.Table,
             limit=0,
         )
-        assert r.render_limited() == "(select * from [mydb].[dbo].[my_table] where 1=0)"
+        assert (
+            r.render_limited()
+            == "(select * from [mydb].[dbo].[my_table] where 1=0) _dbt_limit_subq_my_table"
+        )
 
     def test_limit_positive(self):
         r = FabricRelation.create(
@@ -59,7 +62,10 @@ class TestFabricRelationRenderLimited:
             type=FabricRelationType.Table,
             limit=10,
         )
-        assert r.render_limited() == "(select TOP 10 * from [mydb].[dbo].[my_table])"
+        assert (
+            r.render_limited()
+            == "(select TOP 10 * from [mydb].[dbo].[my_table]) _dbt_limit_subq_my_table"
+        )
 
 
 class TestFabricRelationRendering:

--- a/tests/unit/adapters/fabric/test_fabric_relation.py
+++ b/tests/unit/adapters/fabric/test_fabric_relation.py
@@ -49,10 +49,7 @@ class TestFabricRelationRenderLimited:
             type=FabricRelationType.Table,
             limit=0,
         )
-        result = r.render_limited()
-        assert "where 1=0" in result
-        assert "[mydb].[dbo].[my_table]" in result
-        assert "select *" in result
+        assert r.render_limited() == "(select * from [mydb].[dbo].[my_table] where 1=0)"
 
     def test_limit_positive(self):
         r = FabricRelation.create(
@@ -62,10 +59,7 @@ class TestFabricRelationRenderLimited:
             type=FabricRelationType.Table,
             limit=10,
         )
-        result = r.render_limited()
-        assert "TOP 10" in result
-        assert "[mydb].[dbo].[my_table]" in result
-        assert "select TOP 10 *" in result
+        assert r.render_limited() == "(select TOP 10 * from [mydb].[dbo].[my_table])"
 
 
 class TestFabricRelationRendering:

--- a/tests/unit/adapters/fabric/test_table_refresh.py
+++ b/tests/unit/adapters/fabric/test_table_refresh.py
@@ -1,0 +1,361 @@
+import pytest
+from dbt_common.exceptions import DbtDatabaseError
+
+from dbt.adapters.fabric.fabric_column import FabricColumn
+from dbt.adapters.fabric.table_refresh import (
+    FabricTableColumn,
+    FabricTableConstraint,
+    build_refresh_plan,
+    desired_constraint,
+    diff_constraints,
+    query_references_relation,
+    requires_constraint_replacement,
+)
+
+
+def _column(
+    name="id",
+    data_type="int",
+    max_length=4,
+    precision=10,
+    scale=0,
+    nullable=False,
+    collation=None,
+    identity=False,
+):
+    return FabricTableColumn(
+        name=name,
+        data_type=data_type,
+        max_length=max_length,
+        precision=precision,
+        scale=scale,
+        nullable=nullable,
+        collation=collation,
+        identity=identity,
+    )
+
+
+class TestBuildRefreshPlan:
+    def test_reload_when_schema_and_layout_match(self):
+        columns = [_column(), _column(name="name", data_type="varchar", max_length=100)]
+
+        plan = build_refresh_plan(columns, columns, ["id"], ["ID"])
+
+        assert plan == {
+            "action": "reload",
+            "reason": "schema and physical layout unchanged",
+            "column_names": ["id", "name"],
+        }
+
+    @pytest.mark.parametrize(
+        ("query_columns", "target_columns"),
+        [
+            ([_column(name="new_id")], [_column()]),
+            ([_column(data_type="bigint")], [_column()]),
+            ([_column(max_length=8)], [_column()]),
+            ([_column(precision=12)], [_column()]),
+            ([_column(scale=2)], [_column()]),
+            ([_column(nullable=False)], [_column(nullable=True)]),
+            ([_column(collation="Latin1_General_100_CI_AS")], [_column()]),
+            ([_column(), _column(name="other")], [_column()]),
+        ],
+    )
+    def test_replace_when_schema_changes(self, query_columns, target_columns):
+        plan = build_refresh_plan(query_columns, target_columns, None, [])
+
+        assert plan["action"] == "replace"
+
+    def test_reload_keeps_stricter_target_nullability(self):
+        plan = build_refresh_plan(
+            [_column(nullable=True)],
+            [_column(nullable=False)],
+            None,
+            [],
+        )
+
+        assert plan["action"] == "reload"
+
+    def test_replace_when_identity_is_present(self):
+        column = _column(data_type="bigint", max_length=8, precision=19, identity=True)
+
+        plan = build_refresh_plan([column], [column], None, [])
+
+        assert plan["action"] == "replace"
+        assert plan["reason"] == "identity column present"
+
+    def test_replace_when_cluster_by_changes(self):
+        columns = [_column(), _column(name="created_at", data_type="datetime2")]
+
+        plan = build_refresh_plan(columns, columns, ["created_at"], ["id"])
+
+        assert plan["action"] == "replace"
+        assert plan["reason"] == "physical layout changed"
+
+    def test_cluster_by_order_change_forces_replacement(self):
+        columns = [_column(), _column(name="created_at", data_type="datetime2")]
+
+        plan = build_refresh_plan(columns, columns, ["created_at", "id"], ["id", "created_at"])
+
+        assert plan["action"] == "replace"
+
+
+class TestFabricTableColumn:
+    def test_from_mapping_normalizes_values(self):
+        column = FabricTableColumn.from_mapping(
+            {
+                "name": "Name",
+                "data_type": "VARCHAR",
+                "max_length": "100",
+                "precision": None,
+                "scale": None,
+                "is_nullable": 1,
+                "collation_name": "Latin1_General_100_CI_AS",
+                "is_identity": 0,
+            }
+        )
+
+        assert column == FabricTableColumn(
+            name="Name",
+            data_type="varchar",
+            max_length=100,
+            precision=None,
+            scale=None,
+            nullable=True,
+            collation="latin1_general_100_ci_as",
+            identity=False,
+        )
+
+    def test_from_fabric_column_normalizes_values(self):
+        column = FabricTableColumn.from_column(
+            FabricColumn(
+                column="Name",
+                dtype="VARCHAR",
+                char_size=100,
+                is_nullable=True,
+                collation_name="Latin1_General_100_CI_AS",
+            )
+        )
+
+        assert column == FabricTableColumn(
+            name="Name",
+            data_type="varchar",
+            max_length=100,
+            precision=None,
+            scale=None,
+            nullable=True,
+            collation="latin1_general_100_ci_as",
+            identity=False,
+        )
+
+
+class TestQueryReferencesRelation:
+    def test_detects_quoted_relation(self):
+        assert query_references_relation(
+            "select * from [warehouse].[dbo].[target]",
+            ["[warehouse].[dbo].[target]", "[dbo].[target]"],
+        )
+
+    def test_is_case_insensitive(self):
+        assert query_references_relation(
+            "select * from [DBO].[TARGET]",
+            ["[dbo].[target]"],
+        )
+
+    def test_ignores_unrelated_queries(self):
+        assert not query_references_relation(
+            "select * from [dbo].[source]",
+            ["[dbo].[target]"],
+        )
+
+
+class TestConstraintDiff:
+    def test_unchanged_constraint_is_preserved(self):
+        constraint = FabricTableConstraint("pk_model", "primary_key", ("id",))
+
+        assert diff_constraints([constraint], [constraint]) == ([], [])
+
+    def test_changed_constraint_is_replaced(self):
+        desired = FabricTableConstraint("pk_model", "primary_key", ("new_id",))
+        existing = FabricTableConstraint("pk_model", "primary_key", ("id",))
+
+        assert diff_constraints([desired], [existing]) == (["pk_model"], ["pk_model"])
+
+    def test_added_and_removed_constraints(self):
+        desired = FabricTableConstraint("uq_model", "unique", ("code",))
+        existing = FabricTableConstraint("pk_model", "primary_key", ("id",))
+
+        assert diff_constraints([desired], [existing]) == (["pk_model"], ["uq_model"])
+
+    def test_diff_is_case_insensitive_and_deterministic(self):
+        desired = [
+            FabricTableConstraint("z_constraint", "unique", ("code",)),
+            FabricTableConstraint("A_constraint", "primary_key", ("id",)),
+        ]
+        existing = [
+            FabricTableConstraint("old_z", "unique", ("legacy",)),
+            FabricTableConstraint("OLD_A", "primary_key", ("legacy_id",)),
+        ]
+
+        assert diff_constraints(desired, existing) == (
+            ["OLD_A", "old_z"],
+            ["A_constraint", "z_constraint"],
+        )
+
+    def test_duplicate_desired_names_are_rejected_case_insensitively(self):
+        constraints = [
+            FabricTableConstraint("PK_Model", "primary_key", ("id",)),
+            FabricTableConstraint("pk_model", "primary_key", ("id",)),
+        ]
+
+        with pytest.raises(DbtDatabaseError, match="Duplicate desired"):
+            diff_constraints(constraints, [])
+
+    def test_desired_foreign_key_parses_expression(self):
+        constraint = desired_constraint(
+            {
+                "name": "fk_order",
+                "type": "foreign_key",
+                "columns": ["order_id"],
+                "expression": "[sales].[orders] ([id])",
+            }
+        )
+
+        assert constraint == FabricTableConstraint(
+            name="fk_order",
+            constraint_type="foreign_key",
+            columns=("order_id",),
+            referenced_schema="sales",
+            referenced_table="orders",
+            referenced_columns=("id",),
+        )
+
+    def test_foreign_key_database_schema_and_quoted_identifiers_are_preserved(self):
+        constraint = desired_constraint(
+            {
+                "name": "fk_order",
+                "type": "foreign_key",
+                "columns": ["order id"],
+                "expression": "[warehouse].[sales.data].[orders]]archive] ([order id])",
+            }
+        )
+
+        assert constraint == FabricTableConstraint(
+            name="fk_order",
+            constraint_type="foreign_key",
+            columns=("order id",),
+            referenced_database="warehouse",
+            referenced_schema="sales.data",
+            referenced_table="orders]archive",
+            referenced_columns=("order id",),
+        )
+
+    def test_qualified_foreign_key_detects_schema_change(self):
+        desired = FabricTableConstraint(
+            "fk_order",
+            "foreign_key",
+            ("order_id",),
+            referenced_schema="sales",
+            referenced_table="orders",
+            referenced_columns=("id",),
+        )
+        existing = FabricTableConstraint(
+            "fk_order",
+            "foreign_key",
+            ("order_id",),
+            referenced_schema="archive",
+            referenced_table="orders",
+            referenced_columns=("id",),
+        )
+
+        assert diff_constraints([desired], [existing]) == (["fk_order"], ["fk_order"])
+
+    def test_unqualified_foreign_key_matches_resolved_schema(self):
+        desired = FabricTableConstraint(
+            "fk_order",
+            "foreign_key",
+            ("order_id",),
+            referenced_table="orders",
+            referenced_columns=("id",),
+        )
+        existing = FabricTableConstraint(
+            "fk_order",
+            "foreign_key",
+            ("order_id",),
+            referenced_database="warehouse",
+            referenced_schema="dbo",
+            referenced_table="orders",
+            referenced_columns=("id",),
+        )
+
+        assert diff_constraints([desired], [existing]) == ([], [])
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "orders",
+            "orders ()",
+            "sales..orders (id)",
+            "sales orders (id)",
+            "[sales].[orders (id)",
+            "sales.orders (id; drop table users)",
+        ],
+    )
+    def test_invalid_foreign_key_expression_is_rejected(self, expression):
+        with pytest.raises(DbtDatabaseError):
+            desired_constraint(
+                {
+                    "name": "fk_order",
+                    "type": "foreign_key",
+                    "columns": ["order_id"],
+                    "expression": expression,
+                }
+            )
+
+    def test_foreign_key_column_count_must_match(self):
+        with pytest.raises(DbtDatabaseError, match="source columns"):
+            desired_constraint(
+                {
+                    "name": "fk_order",
+                    "type": "foreign_key",
+                    "columns": ["order_id", "tenant_id"],
+                    "expression": "sales.orders (id)",
+                }
+            )
+
+    @pytest.mark.parametrize("constraint_type", ["primary_key", "unique"])
+    def test_supported_constraint_requires_name(self, constraint_type):
+        with pytest.raises(DbtDatabaseError, match="non-empty name"):
+            desired_constraint(
+                {
+                    "type": constraint_type,
+                    "columns": ["id"],
+                }
+            )
+
+    def test_supported_constraint_requires_columns(self):
+        with pytest.raises(DbtDatabaseError, match="at least one"):
+            desired_constraint(
+                {
+                    "name": "pk_model",
+                    "type": "primary_key",
+                    "columns": [],
+                }
+            )
+
+    def test_renderable_custom_constraint_requires_replacement(self):
+        assert requires_constraint_replacement(
+            {
+                "name": "custom_model",
+                "type": "custom",
+                "expression": "constraint custom_model unique (id)",
+            }
+        )
+
+    def test_non_renderable_constraint_does_not_require_replacement(self):
+        assert not requires_constraint_replacement(
+            {
+                "name": "check_model",
+                "type": "check",
+                "expression": "id > 0",
+            }
+        )

--- a/tests/unit/adapters/fabric/test_transaction_boundaries.py
+++ b/tests/unit/adapters/fabric/test_transaction_boundaries.py
@@ -1,0 +1,146 @@
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).parents[4]
+MACRO_ROOT = REPOSITORY_ROOT / "dbt/include/fabric/macros/materializations"
+ADAPTER_MACRO_ROOT = REPOSITORY_ROOT / "dbt/include/fabric/macros/adapters"
+UTILITY_MACRO_ROOT = REPOSITORY_ROOT / "dbt/include/fabric/macros/utils"
+
+
+def _read(relative_path: str) -> str:
+    return (MACRO_ROOT / relative_path).read_text()
+
+
+def _read_adapter_macro(relative_path: str) -> str:
+    return (ADAPTER_MACRO_ROOT / relative_path).read_text()
+
+
+def _read_utility_macro(relative_path: str) -> str:
+    return (UTILITY_MACRO_ROOT / relative_path).read_text()
+
+
+def test_materialization_macros_do_not_manage_nested_transactions():
+    transaction_owned_macros = [
+        "models/table/refresh.sql",
+        "models/table/columns_spec_ddl.sql",
+        "models/table/table.sql",
+        "models/table/clone.sql",
+        "functions/function.sql",
+        "models/incremental/incremental.sql",
+        "models/view/view.sql",
+        "snapshots/snapshot.sql",
+        "seeds/helpers.sql",
+    ]
+
+    for macro_path in transaction_owned_macros:
+        sql = _read(macro_path).upper()
+        assert "BEGIN TRANSACTION" not in sql
+        assert "COMMIT TRANSACTION" not in sql
+        assert "ROLLBACK TRANSACTION" not in sql
+
+
+def test_table_metadata_operations_run_before_commit():
+    sql = _read("models/table/table.sql")
+
+    assert sql.index("reconcile_model_constraints") < sql.index("adapter.commit()")
+    assert sql.index("create_or_update_statistics") < sql.index("adapter.commit()")
+
+
+def test_table_clone_metadata_operations_run_before_commit():
+    sql = _read("models/table/clone.sql")
+
+    assert sql.index("apply_grants") < sql.index("adapter.commit()")
+    assert sql.index("persist_docs") < sql.index("adapter.commit()")
+
+
+def test_function_hooks_and_metadata_run_before_commit():
+    sql = _read("functions/function.sql")
+
+    assert sql.index("apply_grants") < sql.index("adapter.commit()")
+    assert sql.index("persist_docs") < sql.index("adapter.commit()")
+    assert sql.index("run_hooks(post_hooks, inside_transaction=True)") < sql.index(
+        "adapter.commit()"
+    )
+
+
+def test_incremental_metadata_operations_run_before_commit():
+    sql = _read("models/incremental/incremental.sql")
+
+    assert sql.index("reconcile_model_constraints") < sql.index("adapter.commit()")
+    assert sql.index("create_or_update_statistics") < sql.index("adapter.commit()")
+
+
+def test_snapshot_cleanup_and_statistics_run_before_commit():
+    sql = _read("snapshots/snapshot.sql")
+
+    assert sql.index("create_or_update_statistics") < sql.index("adapter.commit()")
+    assert sql.index("post_snapshot(staging_table)") < sql.index("adapter.commit()")
+
+
+def test_view_backup_is_removed_before_commit():
+    sql = _read("models/view/view.sql")
+
+    backup_drop = sql.index("adapter.drop_relation(backup_relation)")
+    assert backup_drop < sql.rindex("adapter.commit()")
+
+
+def test_hooks_no_longer_claim_transactions_are_unsupported():
+    assert "don't support transactions" not in _read("hooks.sql")
+
+
+def test_seed_reset_opens_transaction_before_mutating_existing_table():
+    sql = _read("seeds/helpers.sql")
+
+    begin = sql.index("auto_begin=True")
+    assert begin < sql.index("adapter.drop_relation(old_relation)")
+    assert begin < sql.index("adapter.truncate_relation(old_relation)")
+
+
+def test_read_only_adapter_statements_do_not_open_transactions():
+    read_only_statements = {
+        "metadata.sql": [
+            "list_schemas",
+            "check_schema_exists",
+            "list_relations_without_caching",
+            "list_function_relations_without_caching",
+            "last_modified",
+        ],
+        "columns.sql": ["get_columns_in_relation", "get_columns_in_query"],
+        "relation.sql": ["find_references"],
+        "indexes.sql": ["find_references", "list_nonclustered_rowstore_indexes"],
+        "catalog.sql": ["catalog"],
+        "freshness.sql": ["collect_freshness"],
+    }
+
+    for macro_path, statement_names in read_only_statements.items():
+        sql = _read_adapter_macro(macro_path)
+        for statement_name in statement_names:
+            statement_call = re.search(
+                rf"statement\(\s*'{statement_name}'.*?%\}}",
+                sql,
+                re.DOTALL,
+            )
+            assert statement_call is not None
+            assert "auto_begin=False" in statement_call.group()
+
+
+def test_read_only_utility_statements_do_not_open_transactions():
+    read_only_statements = {
+        "date_spine.sql": ["get_intervals_between"],
+        "validate_sql.sql": [
+            "set_showplan_on",
+            "run_sql",
+            "set_showplan_off",
+        ],
+    }
+
+    for macro_path, statement_names in read_only_statements.items():
+        sql = _read_utility_macro(macro_path)
+        for statement_name in statement_names:
+            statement_call = re.search(
+                rf"statement\(\s*'{statement_name}'.*?%\}}",
+                sql,
+                re.DOTALL,
+            )
+            assert statement_call is not None
+            assert "auto_begin=False" in statement_call.group()


### PR DESCRIPTION
This pull request introduces schema-aware full refreshes for table and incremental models, improves constraint handling, and addresses several important bug fixes. The main focus is on enabling atomic `TRUNCATE`-based refreshes when schema and constraints are unchanged, and on improving the handling of table constraints and aliases. Several internal APIs are extended to support these features, and bugs related to service principal authentication and relation aliasing are fixed.

**Schema-aware full refresh and constraint management:**

* Added `get_table_refresh_plan`, `get_constraints_in_relation`, and related helper methods to `fabric_adapter.py` to support atomic full refreshes that preserve table objects and reconcile constraints when possible. This includes logic for comparing schema, identity, and cluster layout, and for transactional constraint updates.
* Introduced a new `FabricColumn` dataclass in `fabric_column.py` to represent additional column metadata (nullable, collation, identity) required for schema comparison.
* Updated `CHANGELOG.md` to document schema-aware full refreshes and improved constraint handling in v1.11.2rc1.
* Updated imports in `fabric_adapter.py` to include new table refresh utilities.

**Bug fixes and compatibility improvements:**

* Fixed service principal authentication by removing the unsupported `Authority Id` connection string parameter in `fabric_connection_manager.py`, restoring compatibility with `mssql-python` and resolving issue #434.
* Fixed a bug where generated aliases were incorrectly added to explicitly aliased relations with `--empty`, preventing invalid double aliases and resolving issue #437. This involved updating the `require_alias` flag and alias rendering in `fabric_relation.py`. [[1]](diffhunk://#diff-a3667153c138d10f896f6515b0a174037156f11342e5d523975f333089c7d131L13-R13) [[2]](diffhunk://#diff-a3667153c138d10f896f6515b0a174037156f11342e5d523975f333089c7d131L27-R29)

**Version bump:**

* Bumped the package version to `1.11.2rc1` in `__version__.py`.