### PR TITLE
Add guided GitHub issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Report a reproducible problem with dbt-fabric.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Please search existing issues before submitting a new one and remove any sensitive information from logs.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Describe the bug
+      description: What happened, and what behavior did you expect?
+      placeholder: A clear and concise description of the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest dbt project, model, or command sequence that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run `dbt ...`
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: input
+    id: dbt_fabric_version
+    attributes:
+      label: dbt-fabric version
+      description: Run `dbt --version` to find the installed adapter version.
+      placeholder: "1.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: dbt_core_version
+    attributes:
+      label: dbt-core version
+      placeholder: "1.9.0"
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Data platform
+      options:
+        - Fabric Warehouse
+        - Fabric SQL database
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: operating_system
+    attributes:
+      label: Operating system
+      placeholder: "Windows 11, macOS 15, or Ubuntu 24.04"
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and additional context
+      description: Paste relevant logs, stack traces, screenshots, or other context. Remove credentials, connection strings, and other sensitive information.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true
+        - label: I removed credentials and other sensitive information from this report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: dbt Community support
+    url: https://discourse.getdbt.com/
+    about: Ask usage and troubleshooting questions in the dbt Community forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,47 @@
+name: Feature request
+description: Suggest an improvement or new capability for dbt-fabric.
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve dbt-fabric. Please describe the user problem before proposing a solution.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to accomplish, and what limitation are you encountering?
+      placeholder: As a dbt-fabric user, I need ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or capability you would like.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workarounds or alternative approaches you have tried.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add examples, screenshots, links, or other details that may help evaluate the request.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission check
+      options:
+        - label: I searched the existing issues and did not find a duplicate.
+          required: true


### PR DESCRIPTION
## Summary
- add structured bug report and feature request forms
- require key reproduction and environment details for bug reports
- disable blank issues and route support questions to the dbt Community forum

## Testing
- parsed all issue template YAML files successfully
- checked the change for whitespace errors